### PR TITLE
Fix compilation and a crash with Qt 5.7

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -272,6 +272,10 @@ if (ENABLE_QT5)
     find_package(Qt5Svg REQUIRED)
     find_package(Qt5Sql REQUIRED)
 
+    if (${Qt5Widgets_VERSION} VERSION_GREATER "5.6.99")
+        set(CMAKE_CXX_STANDARD "11")
+    endif (${Qt5Widgets_VERSION} VERSION_GREATER "5.6.99")
+
     set(QTCORELIBS ${Qt5Core_LIBRARIES})
     set(QTNETWORKLIBS ${Qt5Network_LIBRARIES})
     set(QTGUILIBS ${Qt5Gui_LIBRARIES})

--- a/online/podcastwidget.cpp
+++ b/online/podcastwidget.cpp
@@ -39,8 +39,6 @@ PodcastWidget::PodcastWidget(PodcastService *s, QWidget *p)
     , srv(s)
     , proxy(this)
 {
-    proxy.setSourceModel(srv);
-    view->setModel(&proxy);
     subscribeAction = new Action(Icons::self()->addNewItemIcon, i18n("Add Subscription"), this);
     unSubscribeAction = new Action(Icon("list-remove"), i18n("Remove Subscription"), this);
     downloadAction = new Action(Icon("go-down"), i18n("Download Episodes"), this);
@@ -48,6 +46,9 @@ PodcastWidget::PodcastWidget(PodcastService *s, QWidget *p)
     cancelDownloadAction = new Action(Icons::self()->cancelIcon, i18n("Cancel Download"), this);
     markAsNewAction = new Action(Icon("document-new"), i18n("Mark Episodes As New"), this);
     markAsListenedAction = new Action(i18n("Mark Episodes As Listened"), this);
+
+    proxy.setSourceModel(srv);
+    view->setModel(&proxy);
 
     view->alwaysShowHeader();
     connect(view, SIGNAL(headerClicked(int)), SLOT(headerClicked(int)));
@@ -298,6 +299,7 @@ void PodcastWidget::controlActions()
     SinglePageWidget::controlActions();
 
     QModelIndexList selected=view->selectedIndexes(false); // Dont need sorted selection here...
+    downloadAction->setEnabled(!selected.isEmpty());
     unSubscribeAction->setEnabled(1==selected.count() && static_cast<PodcastService::Item *>(proxy.mapToSource(selected.first()).internalPointer())->isPodcast());
     downloadAction->setEnabled(!selected.isEmpty());
     deleteAction->setEnabled(!selected.isEmpty());


### PR DESCRIPTION
Qt 5.7 requires C++11 support from the compiler, thus set it if Qt version is greater than 5.6.99. Also, I've had a crash on startup due to a virtual function call from constructor on a partially initialized object. Worked around it by re-arranging constructor code.