### PR TITLE
Fix #972: Fix Japanese translations

### DIFF
--- a/po/ja.po
+++ b/po/ja.po
@@ -5,6 +5,7 @@
 #
 msgid ""
 msgstr ""
+"Plural-Forms: nplurals=1; plural=0;\n"
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-12-27 01:19+0900\n"


### PR DESCRIPTION
From #972. This fixes the following error:
```
po/ja.po:2822: message catalog has plural form translations...
po/ja.po:7: ...but header entry lacks a "plural=EXPRESSION" attribute
            Try using the following, valid for Japanese:
            "Plural-Forms: nplurals=1; plural=0;\n"
po/ja.po:7: ...but header entry lacks a "nplurals=INTEGER" attribute
            Try using the following, valid for Japanese:
            "Plural-Forms: nplurals=1; plural=0;\n"
```
I can't vouch for the accuracy of the translations, but it builds successfully now.

```