### PR TITLE
Data type fix in osxstyle

### DIFF
--- a/support/osxstyle.cpp
+++ b/support/osxstyle.cpp
@@ -53,7 +53,7 @@ const QPalette & OSXStyle::viewPalette()
     return viewWidget()->palette();
 }
 
-void OSXStyle::drawSelection(StyleOptionViewItem opt, QPainter *painter, double opacity)
+void OSXStyle::drawSelection(StyleOptionViewItem &opt, QPainter *painter, double opacity)
 {
     opt.palette=viewPalette();
     if (opacity<0.999) {

--- a/support/osxstyle.h
+++ b/support/osxstyle.h
@@ -48,7 +48,7 @@ public:
 
     OSXStyle();
     const QPalette & viewPalette();
-    void drawSelection(const StyleOptionViewItem &opt, QPainter *painter, double opacity);
+    void drawSelection(StyleOptionViewItem &opt, QPainter *painter, double opacity);
     QColor monoIconColor();
 
     void initWindowMenu(QMainWindow *mw);


### PR DESCRIPTION
Fixed data type, header declared const pointer, while source non-static
variable

This fixes the only compiling error on MacOS. Some icons still are messed up, but I assume that is not OS-X specific