### PR TITLE
Fix for latest qt5 avaliable from homebrew on OS X

### DIFF
--- a/README
+++ b/README
@@ -829,23 +829,21 @@ These steps assume the following structure:
     build/
     install/
 
-1. Install Qt5.3.1 (or later) from https://www.qt.io/download-open-source/
+1. Install HomeBrew
 
-2. Install HomeBrew
+2. brew install cmake taglib ffmpeg openssl qt5
 
-3. brew install cmake taglib ffmpeg openssl
+3. Load cantata's CMakeLists.txt in QtCreator, and pass the following to cmake:
+     ../src -DCMAKE_PREFIX_PATH=/usr/local/Cellar/qt5/5.9.1/ -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=`pwd`/../install
 
-4. Load cantata's CMakeLists.txt in QtCreator, and pass the following to cmake:
-     ../src -DCMAKE_PREFIX_PATH=/Users/$USER/Qt/5.3/clang_64/ -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=`pwd`/../install
+4. Build via QtCreator
 
-5. Build via QtCreator
-
-6. Create an 'install' project in QtCreator
+5. Create an 'install' project in QtCreator
   - Projects
   - Add/Clone Selected
   - Expand Build Steps, and select install
 
-7. Build 'install' project via QtCreator
+6. Build 'install' project via QtCreator
 
 
 Create Installer

--- a/gui/application.cpp
+++ b/gui/application.cpp
@@ -43,7 +43,7 @@ void Application::init()
     #if defined Q_OS_WIN
     ProxyStyle *proxy=new ProxyStyle(ProxyStyle::VF_Side);
     #elif defined Q_OS_MAC
-    ProxyStyle *proxy=ProxyStyle(ProxyStyle::VF_Side|ProxyStyle::VF_Top);
+    ProxyStyle *proxy=new ProxyStyle(ProxyStyle::VF_Side|ProxyStyle::VF_Top);
     #else
     ProxyStyle *proxy=new ProxyStyle(0);
     #endif


### PR DESCRIPTION
This fixes this compile issue on OS X:
```
/Users/mwheeler/Downloads/cantata/gui/application.cpp:46:17: error: no viable conversion from 'ProxyStyle' to 'ProxyStyle *'
    ProxyStyle *proxy=ProxyStyle(ProxyStyle::VF_Side|ProxyStyle::VF_Top);
                ^     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
make[2]: *** [CMakeFiles/cantata.dir/gui/application.cpp.o] Error 1
make[1]: *** [CMakeFiles/cantata.dir/all] Error 2
make: *** [all] Error 2
```

I've also updated the README to reflect installing qt5 from homebrew.