### PR TITLE
fix compiler error from missing utils header in search widget

### DIFF
--- a/widgets/searchwidget.cpp
+++ b/widgets/searchwidget.cpp
@@ -23,6 +23,7 @@
 
 #include "searchwidget.h"
 #include "support/monoicon.h"
+#include "support/utils.h"
 #include "toolbutton.h"
 #include <QHBoxLayout>
 #include <QKeyEvent>


### PR DESCRIPTION
I was getting a compiler error in `searchWidget.cpp` without the `utils` header included.