### PR TITLE
Fix build error

### DIFF
--- a/support/inputdialog.h
+++ b/support/inputdialog.h
@@ -25,10 +25,10 @@
 #define INPUT_DIALOG_H
 
 #include <QLineEdit>
+#include <QSpinBox>
 #include <QWidget>
 #include "dialog.h"
 
-class QSpinBox;
 class LineEdit;
 
 class InputDialog : public Dialog


### PR DESCRIPTION
source/cantata/gui/mainwindow.cpp: In member function ‘void MainWindow::addWithPriority()’:
source/cantata/gui/mainwindow.cpp:1915:27: error: invalid use of incomplete type ‘class QSpinBox’
         prio=dlg.spinBox()->value();
                           ^
In file included from /home/tux/source/cantata/gui/mainwindow.cpp:31:0:
source/cantata/support/inputdialog.h:31:7: note: forward declaration of ‘class QSpinBox’
 class QSpinBox;
