### PR TITLE
Fix build error

### DIFF
--- a/3rdparty/solid-lite/backends/udisks2/udisksopticaldisc.cpp
+++ b/3rdparty/solid-lite/backends/udisks2/udisksopticaldisc.cpp
@@ -32,6 +32,7 @@
 #include "../shared/udevqt.h"
 
 #include "udisks2.h"
+#include "udisksdevice.h"
 #include "udisksopticaldisc.h"
 #include "soliddefs_p.h"
 


### PR DESCRIPTION
3rdparty/solid-lite/libsolidlite.a(udisksopticaldisc.cpp.o): In function `Solid::Backends::UDisks2::OpticalDisc::OpticalDisc(Solid::Backends::UDisks2::Device*)':
/home/tux/source/cantata/3rdparty/solid-lite/backends/udisks2/udisksopticaldisc.cpp:176: undefined reference to `UdevQt::Device::Device()'
/home/tux/source/cantata/3rdparty/solid-lite/backends/udisks2/udisksopticaldisc.cpp:178: undefined reference to `UdevQt::Client::Client(QObject*)'
/home/tux/source/cantata/3rdparty/solid-lite/backends/udisks2/udisksopticaldisc.cpp:179: undefined reference to `UdevQt::Client::deviceByDeviceFile(QString const&)'
/home/tux/source/cantata/3rdparty/solid-lite/backends/udisks2/udisksopticaldisc.cpp:179: undefined reference to `UdevQt::Device::operator=(UdevQt::Device const&)'
/home/tux/source/cantata/3rdparty/solid-lite/backends/udisks2/udisksopticaldisc.cpp:179: undefined reference to `UdevQt::Device::~Device()'
/home/tux/source/cantata/3rdparty/solid-lite/backends/udisks2/udisksopticaldisc.cpp:181: undefined reference to `UdevQt::Device::deviceProperties() const'
/home/tux/source/cantata/3rdparty/solid-lite/backends/udisks2/udisksopticaldisc.cpp:178: undefined reference to `UdevQt::Client::~Client()'
/home/tux/source/cantata/3rdparty/solid-lite/backends/udisks2/udisksopticaldisc.cpp:179: undefined reference to `UdevQt::Device::~Device()'
/home/tux/source/cantata/3rdparty/solid-lite/backends/udisks2/udisksopticaldisc.cpp:178: undefined reference to `UdevQt::Client::~Client()'
/home/tux/source/cantata/3rdparty/solid-lite/backends/udisks2/udisksopticaldisc.cpp:176: undefined reference to `UdevQt::Device::~Device()'
3rdparty/solid-lite/libsolidlite.a(udisksopticaldisc.cpp.o): In function `Solid::Backends::UDisks2::OpticalDisc::OpticalDisc(Solid::Backends::UDisks2::Device*)':
/home/tux/source/cantata/3rdparty/solid-lite/backends/udisks2/udisksopticaldisc.cpp:176: undefined reference to `UdevQt::Device::Device()'
/home/tux/source/cantata/3rdparty/solid-lite/backends/udisks2/udisksopticaldisc.cpp:178: undefined reference to `UdevQt::Client::Client(QObject*)'
/home/tux/source/cantata/3rdparty/solid-lite/backends/udisks2/udisksopticaldisc.cpp:179: undefined reference to `UdevQt::Client::deviceByDeviceFile(QString const&)'
/home/tux/source/cantata/3rdparty/solid-lite/backends/udisks2/udisksopticaldisc.cpp:179: undefined reference to `UdevQt::Device::operator=(UdevQt::Device const&)'
/home/tux/source/cantata/3rdparty/solid-lite/backends/udisks2/udisksopticaldisc.cpp:179: undefined reference to `UdevQt::Device::~Device()'
/home/tux/source/cantata/3rdparty/solid-lite/backends/udisks2/udisksopticaldisc.cpp:181: undefined reference to `UdevQt::Device::deviceProperties() const'
/home/tux/source/cantata/3rdparty/solid-lite/backends/udisks2/udisksopticaldisc.cpp:178: undefined reference to `UdevQt::Client::~Client()'
/home/tux/source/cantata/3rdparty/solid-lite/backends/udisks2/udisksopticaldisc.cpp:179: undefined reference to `UdevQt::Device::~Device()'
/home/tux/source/cantata/3rdparty/solid-lite/backends/udisks2/udisksopticaldisc.cpp:178: undefined reference to `UdevQt::Client::~Client()'
/home/tux/source/cantata/3rdparty/solid-lite/backends/udisks2/udisksopticaldisc.cpp:176: undefined reference to `UdevQt::Device::~Device()'
3rdparty/solid-lite/libsolidlite.a(udisksopticaldisc.cpp.o): In function `Solid::Backends::UDisks2::OpticalDisc::~OpticalDisc()':
/home/tux/source/cantata/3rdparty/solid-lite/backends/udisks2/udisksopticaldisc.cpp:188: undefined reference to `UdevQt::Device::~Device()'
3rdparty/solid-lite/libsolidlite.a(udisksopticaldisc.cpp.o): In function `Solid::Backends::UDisks2::OpticalDisc::~OpticalDisc()':
/home/tux/source/cantata/3rdparty/solid-lite/backends/udisks2/udisksopticaldisc.cpp:188: undefined reference to `UdevQt::Device::~Device()'
3rdparty/solid-lite/libsolidlite.a(udisksopticaldisc.cpp.o): In function `Solid::Backends::UDisks2::OpticalDisc::isAppendable() const':
/home/tux/source/cantata/3rdparty/solid-lite/backends/udisks2/udisksopticaldisc.cpp:215: undefined reference to `UdevQt::Device::deviceProperty(QString const&) const'
3rdparty/solid-lite/libsolidlite.a(udisksstoragedrive.cpp.o): In function `Solid::Backends::UDisks2::StorageDrive::StorageDrive(Solid::Backends::UDisks2::Device*)':
/home/tux/source/cantata/3rdparty/solid-lite/backends/udisks2/udisksstoragedrive.cpp:32: undefined reference to `UdevQt::Device::Device()'
/home/tux/source/cantata/3rdparty/solid-lite/backends/udisks2/udisksstoragedrive.cpp:34: undefined reference to `UdevQt::Client::Client(QObject*)'
/home/tux/source/cantata/3rdparty/solid-lite/backends/udisks2/udisksstoragedrive.cpp:35: undefined reference to `UdevQt::Client::deviceByDeviceFile(QString const&)'
/home/tux/source/cantata/3rdparty/solid-lite/backends/udisks2/udisksstoragedrive.cpp:35: undefined reference to `UdevQt::Device::operator=(UdevQt::Device const&)'
/home/tux/source/cantata/3rdparty/solid-lite/backends/udisks2/udisksstoragedrive.cpp:35: undefined reference to `UdevQt::Device::~Device()'
/home/tux/source/cantata/3rdparty/solid-lite/backends/udisks2/udisksstoragedrive.cpp:36: undefined reference to `UdevQt::Device::deviceProperties() const'
/home/tux/source/cantata/3rdparty/solid-lite/backends/udisks2/udisksstoragedrive.cpp:34: undefined reference to `UdevQt::Client::~Client()'
/home/tux/source/cantata/3rdparty/solid-lite/backends/udisks2/udisksstoragedrive.cpp:35: undefined reference to `UdevQt::Device::~Device()'
/home/tux/source/cantata/3rdparty/solid-lite/backends/udisks2/udisksstoragedrive.cpp:34: undefined reference to `UdevQt::Client::~Client()'
/home/tux/source/cantata/3rdparty/solid-lite/backends/udisks2/udisksstoragedrive.cpp:32: undefined reference to `UdevQt::Device::~Device()'
3rdparty/solid-lite/libsolidlite.a(udisksstoragedrive.cpp.o): In function `Solid::Backends::UDisks2::StorageDrive::StorageDrive(Solid::Backends::UDisks2::Device*)':
/home/tux/source/cantata/3rdparty/solid-lite/backends/udisks2/udisksstoragedrive.cpp:32: undefined reference to `UdevQt::Device::Device()'
/home/tux/source/cantata/3rdparty/solid-lite/backends/udisks2/udisksstoragedrive.cpp:34: undefined reference to `UdevQt::Client::Client(QObject*)'
/home/tux/source/cantata/3rdparty/solid-lite/backends/udisks2/udisksstoragedrive.cpp:35: undefined reference to `UdevQt::Client::deviceByDeviceFile(QString const&)'
/home/tux/source/cantata/3rdparty/solid-lite/backends/udisks2/udisksstoragedrive.cpp:35: undefined reference to `UdevQt::Device::operator=(UdevQt::Device const&)'
/home/tux/source/cantata/3rdparty/solid-lite/backends/udisks2/udisksstoragedrive.cpp:35: undefined reference to `UdevQt::Device::~Device()'
/home/tux/source/cantata/3rdparty/solid-lite/backends/udisks2/udisksstoragedrive.cpp:36: undefined reference to `UdevQt::Device::deviceProperties() const'
/home/tux/source/cantata/3rdparty/solid-lite/backends/udisks2/udisksstoragedrive.cpp:34: undefined reference to `UdevQt::Client::~Client()'
/home/tux/source/cantata/3rdparty/solid-lite/backends/udisks2/udisksstoragedrive.cpp:35: undefined reference to `UdevQt::Device::~Device()'
/home/tux/source/cantata/3rdparty/solid-lite/backends/udisks2/udisksstoragedrive.cpp:34: undefined reference to `UdevQt::Client::~Client()'
/home/tux/source/cantata/3rdparty/solid-lite/backends/udisks2/udisksstoragedrive.cpp:32: undefined reference to `UdevQt::Device::~Device()'
3rdparty/solid-lite/libsolidlite.a(udisksstoragedrive.cpp.o): In function `Solid::Backends::UDisks2::StorageDrive::~StorageDrive()':
/home/tux/source/cantata/3rdparty/solid-lite/backends/udisks2/udisksstoragedrive.cpp:39: undefined reference to `UdevQt::Device::~Device()'
3rdparty/solid-lite/libsolidlite.a(udisksstoragedrive.cpp.o): In function `Solid::Backends::UDisks2::StorageDrive::~StorageDrive()':
/home/tux/source/cantata/3rdparty/solid-lite/backends/udisks2/udisksstoragedrive.cpp:39: undefined reference to `UdevQt::Device::~Device()'
3rdparty/solid-lite/libsolidlite.a(udisksstoragedrive.cpp.o): In function `Solid::Backends::UDisks2::StorageDrive::bus() const':
/home/tux/source/cantata/3rdparty/solid-lite/backends/udisks2/udisksstoragedrive.cpp:112: undefined reference to `UdevQt::Device::deviceProperty(QString const&) const'
/home/tux/source/cantata/3rdparty/solid-lite/backends/udisks2/udisksstoragedrive.cpp:118: undefined reference to `UdevQt::Device::deviceProperty(QString const&) const'
collect2: error: ld returned 1 exit status