### PR TITLE
Add avahi support (Issue #955)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,20 @@ option(ENABLE_MUSICBRAINZ "Enable MusicBrianz libraries (either this or CDDB req
 option(ENABLE_UDISKS2 "Build UDisks2 backend, and NOT UDisks, for Qt builds" ON)
 option(ENABLE_REMOTE_DEVICES "Enable support for remote (sshfs, samba) devices (EXPERIMENTAL)" OFF)
 option(ENABLE_MTP "Enable MTP library (required to support MTP devices)" ON)
+option(ENABLE_AVAHI "Enable automatic mpd server discovery" ${UNIX})
+
+if(ENABLE_AVAHI)
+    find_package(Avahi)
+    macro_log_feature(AVAHI_FOUND "Avahi Support" "Automatic MPD-Server Detection" "https://www.avahi.org/" FALSE "" "")
+endif()
+
+if (AVAHI_FOUND)
+    set(CANTATA_SRCS ${CANTATA_SRCS} gui/findmpddialog.cpp gui/avahidiscovery.cpp gui/avahipoll.cpp)
+    set(CANTATA_MOC_HDRS ${CANTATA_MOC_HDRS} gui/findmpddialog.h gui/avahidiscovery.cpp gui/avahipoll.h gui/avahidiscovery.h)
+    set(CANTATA_UIS ${CANTATA_UIS} gui/findmpddialog.ui)
+
+    set(CANTATA_LIBS ${CANTATA_LIBS} ${AVAHI_LIBRARIES})
+endif()
 
 if (NOT APPLE AND NOT WIN32)
     set(SHARE_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}/share"

--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,7 @@
 1. Only disable system tray support if org.kde.StatusNotifierWatcher is not
    registered when running under Gnome.
 2. Add ability to change grid cover size - Ctrl+ / Ctrl-
+3. Avahi support (automatic mpd discovery)
 
 2.2.0
 -----

--- a/INSTALL
+++ b/INSTALL
@@ -75,6 +75,10 @@ The following options may be passed to CMake:
         Enable support for basic, Cantata controlled, MPD instance.
         Default: ON
 
+    -DENABLE_AVAHI=ON
+        Enable avahi support (automatic mpd discovery)
+        Default: ON
+
     Windows specific:
 
     -DCANTATA_WINDOWS_INSTALLER_DEST=<folder>

--- a/README
+++ b/README
@@ -89,6 +89,7 @@ Cantata may also use the following optional libraries:
 7. MusicBrainz5 - either this or CDDB required for Audio CDs
 8. LibEbur128 - ReplayGain detection code. If this is not found on the
    system then Cantata will use its own bundled copy.
+9. libavahi-common / libavahi-client - Avahi support (automatic mpd discovery)
 
 
 3. Building

--- a/cmake/FindAvahi.cmake
+++ b/cmake/FindAvahi.cmake
@@ -1,0 +1,32 @@
+# Try to find the Avahi libraries and headers
+# Once done this will define:
+#
+#  AVAHI_FOUND          - system has the avahi libraries
+#  AVAHI_INCLUDE_DIRS   - the avahi include directories
+#  AVAHI_LIBRARIES      - The libraries needed to use avahi
+
+
+find_library(AVAHI_COMMON_LIB avahi-common PATHS ${COMMON_LIB_DIR})
+find_library(AVAHI_CLIENT_LIB avahi-client PATHS ${CLIENT_LIB_DIR})
+
+if(AVAHI_COMMON_LIB AND AVAHI_CLIENT_LIB)
+    set(AVAHI_LIBRARIES ${AVAHI_COMMON_LIB} ${AVAHI_CLIENT_LIB})
+    message(STATUS "Avahi-Libs found: ${AVAHI_LIBRARIES}")
+else()
+    message(FATAL_ERROR "Avahi-Libs not found")
+endif()
+
+
+find_path(COMMON_INCLUDE_DIR watch.h  PATH_SUFFIXES avahi-common HINTS ${COMMON_INCLUDE_DIR})
+find_path(CLIENT_INCLUDE_DIR client.h PATH_SUFFIXES avahi-client HINTS ${CLIENT_INCLUDE_DIR})
+
+if(COMMON_INCLUDE_DIR AND CLIENT_INCLUDE_DIR)
+    set(AVAHI_INCLUDE_DIRS ${COMMON_INCLUDE_DIR} ${CLIENT_INCLUDE_DIR})
+    message(STATUS "Avahi-Include-Dirs found: ${AVAHI_INCLUDE_DIRS}")
+else()
+    message(FATAL_ERROR "Avahi header not found")
+endif()
+
+if(AVAHI_LIBRARIES AND AVAHI_INCLUDE_DIRS)
+    set(AVAHI_FOUND TRUE)
+endif()

--- a/config.h.cmake
+++ b/config.h.cmake
@@ -45,6 +45,7 @@
 #cmakedefine IOKIT_FOUND 1
 #cmakedefine QT_MAC_EXTRAS_FOUND 1
 #cmakedefine ENABLE_SIMPLE_MPD_SUPPORT 1
+#cmakedefine AVAHI_FOUND
 
 #cmakedefine HAVE_CDIO_PARANOIA_H 1
 #cmakedefine HAVE_CDIO_PARANOIA_PARANOIA_H 1

--- a/gui/avahidiscovery.cpp
+++ b/gui/avahidiscovery.cpp
@@ -1,0 +1,152 @@
+/*
+ *Copyright (C) <2017>  Alex B
+ *
+ *This program is free software: you can redistribute it and/or modify
+ *it under the terms of the GNU General Public License as published by
+ *the Free Software Foundation, either version 2 of the License, or
+ *(at your option) any later version.
+ *
+ *This program is distributed in the hope that it will be useful,
+ *but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *GNU General Public License for more details.
+ *
+ *You should have received a copy of the GNU General Public License
+ *along with this program.  If not, see <http://www.gnu.org/licenses/>
+ */
+
+
+#include "avahidiscovery.h"
+
+#include <avahi-common/error.h>
+
+#include <QDebug>
+
+const AvahiPoll* getAvahiPoll(void);
+
+
+AvahiDiscovery *AvahiDiscovery::ptr = nullptr;
+
+void AvahiDiscovery::resolver_callback(
+    AvahiServiceResolver *r,
+    AVAHI_GCC_UNUSED AvahiIfIndex interface,
+    AVAHI_GCC_UNUSED AvahiProtocol protocol,
+    AvahiResolverEvent event,
+    const char *name,
+    AVAHI_GCC_UNUSED const char *type,
+    AVAHI_GCC_UNUSED const char *domain,
+    AVAHI_GCC_UNUSED const char *host_name,
+    const AvahiAddress *address,
+    uint16_t port,
+    AVAHI_GCC_UNUSED AvahiStringList *txt,
+    AVAHI_GCC_UNUSED AvahiLookupResultFlags flags,
+    void *userdata)
+{
+    char a[AVAHI_ADDRESS_STR_MAX];
+
+    switch(event)
+    {
+        case AVAHI_RESOLVER_FAILURE:
+            //avahi resolver not found
+            break;
+        case AVAHI_RESOLVER_FOUND:
+            avahi_address_snprint(a, sizeof(a), address);
+            break;
+    }
+
+    int eventType = *( static_cast<int*>(userdata) );
+    switch(eventType)
+    {
+        case AVAHI_BROWSER_NEW:
+            emit ptr->mpdFound(name, a, port);
+            break;
+        case AVAHI_BROWSER_REMOVE:
+            emit ptr->mpdRemoved(name);
+            break;
+    }
+
+    avahi_service_resolver_free(r);
+    free(userdata);
+}
+
+void AvahiDiscovery::browse_callback(
+    AvahiServiceBrowser *b,
+    AvahiIfIndex interface,
+    AvahiProtocol protocol,
+    AvahiBrowserEvent event,
+    const char *name,
+    const char *type,
+    const char *domain,
+    AVAHI_GCC_UNUSED AvahiLookupResultFlags flags,
+    AVAHI_GCC_UNUSED void* userdata)
+{
+    switch (event)
+    {
+        case AVAHI_BROWSER_FAILURE:
+            fprintf(stderr, "(Browser) %s\n", avahi_strerror(avahi_client_errno(avahi_service_browser_get_client(b))));
+            break;
+        case AVAHI_BROWSER_NEW:
+            if (!(avahi_service_resolver_new (avahi_service_browser_get_client(b), interface, protocol, name, type, domain, AVAHI_PROTO_UNSPEC, AVAHI_LOOKUP_USE_MULTICAST, resolver_callback, new int(AVAHI_BROWSER_NEW))))
+                fprintf(stderr, "Failed to resolve service '%s'\n", name);
+            break;
+        case AVAHI_BROWSER_REMOVE:
+            if (!(avahi_service_resolver_new (avahi_service_browser_get_client(b), interface, protocol, name, type, domain, AVAHI_PROTO_UNSPEC, AVAHI_LOOKUP_USE_MULTICAST, resolver_callback, new int(AVAHI_BROWSER_REMOVE))))
+                fprintf(stderr, "Failed to resolve service '%s'\n", name);
+             break;
+         case AVAHI_BROWSER_ALL_FOR_NOW:
+             //fprintf(stderr, "Service browser: ALL_FOR_NOW\n");
+             break;
+         case AVAHI_BROWSER_CACHE_EXHAUSTED:
+             //fprintf(stderr, "Service browser: CACHE_EXHAUSTED\n");
+             break;
+    }
+}
+
+
+void AvahiDiscovery::client_callback(AvahiClient *c, AvahiClientState state, AVAHI_GCC_UNUSED void *userdata)
+ {
+    assert(c);
+
+    if (state == AVAHI_CLIENT_FAILURE)
+    {
+        fprintf(stderr, "Server connection failure: %s\n", avahi_strerror(avahi_client_errno(c)));
+    }
+ }
+
+
+AvahiDiscovery::AvahiDiscovery()
+{
+    ptr = this;
+
+    /* create avahi client */
+    int error;
+    m_client = avahi_client_new(getAvahiPoll(), AVAHI_CLIENT_IGNORE_USER_CONFIG, client_callback, NULL, &error);
+    if (!m_client)
+    {
+        fprintf(stderr, "Failed to create client: %s\n", avahi_strerror(error));
+        return;
+    }
+
+    /* create avahi browser */
+    m_browser = avahi_service_browser_new(m_client, AVAHI_IF_UNSPEC, AVAHI_PROTO_INET, "_mpd._tcp", NULL, AVAHI_LOOKUP_USE_MULTICAST, browse_callback, m_client);
+    if (!m_browser) 
+    {
+        fprintf(stderr, "Failed to create service browser: %s\n", avahi_strerror(avahi_client_errno(m_client)));
+        return;
+    }
+}
+
+AvahiDiscovery::~AvahiDiscovery()
+{
+    if (m_browser)
+    {
+        avahi_service_browser_free(m_browser);
+    }
+
+    if (m_client)
+    {
+        avahi_client_free(m_client);
+    }
+}
+
+

--- a/gui/avahidiscovery.h
+++ b/gui/avahidiscovery.h
@@ -1,0 +1,82 @@
+/*
+ *Copyright (C) <2017>  Alex B
+ *
+ *This program is free software: you can redistribute it and/or modify
+ *it under the terms of the GNU General Public License as published by
+ *the Free Software Foundation, either version 2 of the License, or
+ *(at your option) any later version.
+ *
+ *This program is distributed in the hope that it will be useful,
+ *but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *GNU General Public License for more details.
+ *
+ *You should have received a copy of the GNU General Public License
+ *along with this program.  If not, see <http://www.gnu.org/licenses/>
+ */
+
+#ifndef AVAHIDISCOVERY_H
+#define AVAHIDISCOVERY_H
+
+#include <avahi-client/client.h>
+#include <avahi-client/lookup.h>
+
+#include <stdio.h>
+#include <assert.h>
+
+#include <QObject>
+
+
+class AvahiDiscovery: public QObject
+{
+    Q_OBJECT
+
+private:
+    AvahiClient* m_client = nullptr;
+    AvahiServiceBrowser* m_browser = nullptr;
+    static AvahiDiscovery *ptr;
+
+
+public:
+    AvahiDiscovery();
+    ~AvahiDiscovery();
+
+    static void client_callback(
+        AvahiClient *c,
+        AvahiClientState state,
+        AVAHI_GCC_UNUSED void * userdata);
+
+    static void resolver_callback(
+        AvahiServiceResolver *r,
+        AvahiIfIndex interface,
+        AvahiProtocol protocol,
+        AvahiResolverEvent event,
+        const char *name,
+        const char *type,
+        const char *domain,
+        const char *host_name,
+        const AvahiAddress *address,
+        uint16_t port,
+        AvahiStringList *txt,
+        AvahiLookupResultFlags flags,
+        void *userdata);
+
+    static void browse_callback(
+        AvahiServiceBrowser *b,
+        AvahiIfIndex interface,
+        AvahiProtocol protocol,
+        AvahiBrowserEvent event,
+        const char *name,
+        const char *type,
+        const char *domain,
+        AVAHI_GCC_UNUSED AvahiLookupResultFlags flags,
+        void* userdata);
+
+signals:
+    void mpdFound(QString name, QString address, int port);
+    void mpdRemoved(QString name);
+
+};
+
+
+#endif // AVAHIDISCOVERY_H

--- a/gui/avahipoll.cpp
+++ b/gui/avahipoll.cpp
@@ -1,0 +1,170 @@
+/*
+ *Copyright (C) <2017>  Alex B
+ *
+ *This program is free software: you can redistribute it and/or modify
+ *it under the terms of the GNU General Public License as published by
+ *the Free Software Foundation, either version 2 of the License, or
+ *(at your option) any later version.
+ *
+ *This program is distributed in the hope that it will be useful,
+ *but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *GNU General Public License for more details.
+ *
+ *You should have received a copy of the GNU General Public License
+ *along with this program.  If not, see <http://www.gnu.org/licenses/>
+ */
+
+#include "avahipoll.h"
+
+#include <avahi-common/timeval.h>
+
+#include <QThread>
+
+
+
+AvahiWatch* avahiWatchNew(const AvahiPoll *ap, int fd, AvahiWatchEvent event, AvahiWatchCallback callback, void *userdata)
+{
+    return new AvahiWatch(fd, event, callback, userdata);
+}
+
+
+void avahiWatchUpdate(AvahiWatch *w, AvahiWatchEvent event)
+{
+    w->setEventType(event);
+}
+
+
+AvahiWatchEvent avahiWatchGetEvents(AvahiWatch *w)
+{
+    return w->previousEvent();
+}
+
+
+void avahiWatchFree(AvahiWatch *w)
+{
+    (w->thread() == QThread::currentThread()) ? delete w : w->deleteLater();
+}
+
+
+AvahiTimeout* avahiTimeoutNew(const AvahiPoll *p, const struct timeval *tv, AvahiTimeoutCallback callback, void *userdata)
+{
+    Q_UNUSED(p)
+    return new AvahiTimeout(tv, callback, userdata);
+}
+
+
+void avahiTimeoutUpdate(AvahiTimeout *t, const struct timeval *tv)
+{
+    t->updateTimeout(tv);
+}
+
+
+void avahiTimeoutFree(AvahiTimeout *t)
+{
+    (t->thread() == QThread::currentThread()) ? delete t : t->deleteLater();
+}
+
+
+const AvahiPoll* getAvahiPoll(void)
+{
+    static const AvahiPoll avahiPoll =
+    {
+        nullptr,
+        avahiWatchNew,
+        avahiWatchUpdate,
+        avahiWatchGetEvents,
+        avahiWatchFree,
+        avahiTimeoutNew,
+        avahiTimeoutUpdate,
+        avahiTimeoutFree
+    };
+
+    return &avahiPoll;
+}
+
+
+AvahiTimeout::AvahiTimeout(const struct timeval *tv, AvahiTimeoutCallback callback, void *userdata)
+    : m_callback(callback)
+    , m_userdata(userdata)
+{
+    connect(&m_timer, &QTimer::timeout, this, &AvahiTimeout::timeout);
+    updateTimeout(tv);
+}
+
+
+void AvahiTimeout::updateTimeout(const struct timeval *tv)
+{
+    if(tv == 0)
+    {
+        m_timer.stop();
+        return;
+    }
+
+    qint64 msecs = (avahi_age(tv)) / 1000;
+
+    msecs = (msecs > 0) ? 0 : -msecs;
+
+    m_timer.setInterval(msecs);
+    m_timer.start();
+}
+
+
+void AvahiTimeout::timeout()
+{
+    m_timer.stop();
+    m_callback(this, m_userdata);
+}
+
+
+AvahiWatch::AvahiWatch(int fd, AvahiWatchEvent event, AvahiWatchCallback callback, void *userdata)
+    : m_notifier(0)
+    , m_callback(callback)
+    , m_event(event)
+    , m_previousEvent(static_cast<AvahiWatchEvent>(0))
+    , m_userdata(userdata)
+    , m_fd(fd)
+{
+    setEventType(event);
+}
+
+
+void AvahiWatch::setEventType(AvahiWatchEvent event)
+{
+    m_event = event;
+
+    switch(m_event)
+    {
+        case AVAHI_WATCH_IN:
+        {
+            m_notifier.reset(new QSocketNotifier(m_fd, QSocketNotifier::Read, this));
+            connect(m_notifier.data(), &QSocketNotifier::activated, this, &AvahiWatch::activated);
+            break;
+        }
+        case AVAHI_WATCH_OUT:
+        {
+            m_notifier.reset(new QSocketNotifier(m_fd, QSocketNotifier::Write, this));
+            connect(m_notifier.data(), &QSocketNotifier::activated, this, &AvahiWatch::activated);
+            break;
+        }
+        default:
+            // should not be reached
+            break;
+    }
+}
+
+
+void AvahiWatch::activated(int fd)
+{
+    Q_UNUSED(fd)
+
+    m_previousEvent = m_event;
+    m_callback(this, m_fd, m_event, m_userdata);
+    m_previousEvent = static_cast<AvahiWatchEvent>(0);
+}
+
+
+AvahiWatchEvent AvahiWatch::previousEvent()
+{
+    return m_previousEvent;
+}

--- a/gui/avahipoll.h
+++ b/gui/avahipoll.h
@@ -1,0 +1,68 @@
+/*
+ *Copyright (C) <2017>  Alex B
+ *
+ *This program is free software: you can redistribute it and/or modify
+ *it under the terms of the GNU General Public License as published by
+ *the Free Software Foundation, either version 2 of the License, or
+ *(at your option) any later version.
+ *
+ *This program is distributed in the hope that it will be useful,
+ *but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *GNU General Public License for more details.
+ *
+ *You should have received a copy of the GNU General Public License
+ *along with this program.  If not, see <http://www.gnu.org/licenses/>
+ */
+
+#ifndef AVAHIPOLL_H
+#define AVAHIPOLL_H
+
+#include <avahi-common/watch.h>
+
+#include <QObject>
+#include <QSocketNotifier>
+#include <QTimer>
+
+
+class AvahiTimeout: public QObject
+{
+    Q_OBJECT
+
+public:
+    AvahiTimeout(const struct timeval *tv, AvahiTimeoutCallback callback, void *userdata);
+    void updateTimeout(const struct timeval *tv);
+
+private:
+    QTimer m_timer;
+    AvahiTimeoutCallback m_callback;
+    void *m_userdata;
+
+private slots:
+    void timeout();
+};
+
+
+class AvahiWatch: public QObject
+{
+    Q_OBJECT
+
+public:
+    AvahiWatch(int fd, AvahiWatchEvent event, AvahiWatchCallback callback, void *userdata);
+    void setEventType(AvahiWatchEvent event);
+    AvahiWatchEvent previousEvent();
+
+private:
+    QScopedPointer<QSocketNotifier> m_notifier;
+    AvahiWatchCallback m_callback;
+    AvahiWatchEvent m_event;
+    AvahiWatchEvent m_previousEvent;
+    void *m_userdata;
+    int m_fd;
+
+private slots:
+    void activated(int);
+};
+
+
+#endif //AVAHIPOLL_H

--- a/gui/findmpddialog.cpp
+++ b/gui/findmpddialog.cpp
@@ -1,0 +1,87 @@
+/*
+ *Copyright (C) <2017>  Alex B
+ *
+ *This program is free software: you can redistribute it and/or modify
+ *it under the terms of the GNU General Public License as published by
+ *the Free Software Foundation, either version 3 of the License, or
+ *(at your option) any later version.
+ *
+ *This program is distributed in the hope that it will be useful,
+ *but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *GNU General Public License for more details.
+ *
+ *You should have received a copy of the GNU General Public License
+ *along with this program.  If not, see <http://www.gnu.org/licenses/>
+ */
+
+#include "findmpddialog.h"
+
+#include <QDebug>
+#include <QPushButton>
+
+
+
+FindMpdDialog::FindMpdDialog(QWidget *p)
+    : QDialog(p)
+    , avahi(new AvahiDiscovery())
+{
+    setupUi(this);
+
+    tableWidget->setColumnCount(3);
+    tableWidget->setHorizontalHeaderLabels({tr("Name"), tr("Address"), tr("Port")});
+    tableWidget->resizeColumnToContents(0);
+    tableWidget->resizeColumnToContents(1);
+
+    QObject::connect(avahi.data(), &AvahiDiscovery::mpdFound, this, &FindMpdDialog::addMpd);
+    QObject::connect(avahi.data(), &AvahiDiscovery::mpdRemoved, this, &FindMpdDialog::removeMpd);
+    QObject::connect(this, &QDialog::accepted, this, &FindMpdDialog::okClicked);
+
+    buttonBox->button(QDialogButtonBox::Ok)->setEnabled(false);
+    QObject::connect(tableWidget, &QTableWidget::itemSelectionChanged, this, [this](){ buttonBox->button(QDialogButtonBox::Ok)->setEnabled(true); });
+}
+
+
+void FindMpdDialog::addMpd(QString name, QString address, int port)
+{
+    int rowCount = tableWidget->model()->rowCount();
+    tableWidget->insertRow(rowCount);
+
+    tableWidget->setItem(rowCount, 0, new QTableWidgetItem(name));
+    tableWidget->setItem(rowCount, 1, new QTableWidgetItem(address));
+    tableWidget->setItem(rowCount, 2, new QTableWidgetItem( QString::number(port) ));
+
+    tableWidget->resizeColumnToContents(0);
+    tableWidget->resizeColumnToContents(1);
+}
+
+
+void FindMpdDialog::removeMpd(QString name)
+{
+    for(int row = 0; row <= tableWidget->rowCount(); row++)
+    {
+        auto nameItem = tableWidget->item(row, 0);
+
+        if(nameItem->text() == name)
+        {
+            tableWidget->removeRow(row);
+            return;
+        }
+    }
+}
+
+
+void FindMpdDialog::okClicked()
+{
+    QItemSelectionModel *selection = tableWidget->selectionModel();
+
+    if(selection->hasSelection())
+    {
+        QModelIndexList indexList = selection->selectedRows();
+        QModelIndex addressIndex = selection->selectedRows(1).first();
+        QModelIndex portIndex = selection->selectedRows(2).first();
+
+        emit serverChosen(tableWidget->item(addressIndex.row(), addressIndex.column())->text(), tableWidget->item(portIndex.row(), portIndex.column())->text());
+    }
+}
+

--- a/gui/findmpddialog.h
+++ b/gui/findmpddialog.h
@@ -1,0 +1,47 @@
+/*
+ *Copyright (C) <2017>  Alex B
+ *
+ *This program is free software: you can redistribute it and/or modify
+ *it under the terms of the GNU General Public License as published by
+ *the Free Software Foundation, either version 3 of the License, or
+ *(at your option) any later version.
+ *
+ *This program is distributed in the hope that it will be useful,
+ *but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *GNU General Public License for more details.
+ *
+ *You should have received a copy of the GNU General Public License
+ *along with this program.  If not, see <http://www.gnu.org/licenses/>
+ */
+
+#ifndef FINDMPDDIALOG_H
+#define FINDMPDDIALOG_H
+
+#include "avahidiscovery.h"
+#include "ui_findmpddialog.h"
+
+#include <QDebug>
+
+
+class FindMpdDialog : public QDialog, private Ui::FindMpdDialog
+{
+    Q_OBJECT
+
+public:
+    FindMpdDialog(QWidget *p);
+
+signals:
+    void serverChosen(QString ip, QString port);
+
+public slots:
+    void addMpd(QString name, QString address, int port);
+    void removeMpd(QString name);
+    void okClicked();
+
+private:
+    QScopedPointer<AvahiDiscovery> avahi;
+};
+
+
+#endif // FINDMPDDIALOG_H

--- a/gui/findmpddialog.ui
+++ b/gui/findmpddialog.ui
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>FindMpdDialog</class>
+ <widget class="QDialog" name="FindMpdDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>478</width>
+    <height>310</height>
+   </rect>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>470</width>
+    <height>300</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>Server detection</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Please select your MPD. If you don't see your MPD listed here, check that zeroconf is activated in your MPD configuration or insert the host configuration manually.</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+     <property name="textInteractionFlags">
+      <set>Qt::TextSelectableByMouse</set>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QTableWidget" name="tableWidget">
+     <property name="editTriggers">
+      <set>QAbstractItemView::NoEditTriggers</set>
+     </property>
+     <property name="selectionMode">
+      <enum>QAbstractItemView::SingleSelection</enum>
+     </property>
+     <property name="selectionBehavior">
+      <enum>QAbstractItemView::SelectRows</enum>
+     </property>
+     <property name="showGrid">
+      <bool>true</bool>
+     </property>
+     <property name="sortingEnabled">
+      <bool>true</bool>
+     </property>
+     <attribute name="horizontalHeaderStretchLastSection">
+      <bool>true</bool>
+     </attribute>
+     <attribute name="verticalHeaderVisible">
+      <bool>false</bool>
+     </attribute>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>FindMpdDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>FindMpdDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/gui/initialsettingswizard.cpp
+++ b/gui/initialsettingswizard.cpp
@@ -31,6 +31,9 @@
 #ifdef ENABLE_SIMPLE_MPD_SUPPORT
 #include "mpd-interface/mpduser.h"
 #endif
+#ifdef AVAHI_FOUND
+#include "findmpddialog.h"
+#endif
 #include <QDir>
 #include <QStandardPaths>
 #include <QTimer>
@@ -113,11 +116,32 @@ InitialSettingsWizard::InitialSettingsWizard(QWidget *p)
     setMinimumSize(sz);
     #endif
     httpNote->setOn(true);
+
+    #ifdef AVAHI_FOUND
+    discoveryButton = new QPushButton(tr("Discover..."), this);
+    hostLayout->insertWidget(0, discoveryButton);
+    connect(discoveryButton, &QPushButton::clicked, this, &InitialSettingsWizard::detectMPDs);
+    #endif
 }
 
 InitialSettingsWizard::~InitialSettingsWizard()
 {
 }
+
+#ifdef AVAHI_FOUND
+void InitialSettingsWizard::adoptServerSettings(QString ip, QString p)
+{
+    host->setText(ip);
+    port->setValue(p.toInt());
+}
+
+void InitialSettingsWizard::detectMPDs()
+{
+    FindMpdDialog findMpdDlg(this);
+    QObject::connect(&findMpdDlg, &FindMpdDialog::serverChosen, this, &InitialSettingsWizard::adoptServerSettings);
+    findMpdDlg.exec();
+}
+#endif
 
 MPDConnectionDetails InitialSettingsWizard::getDetails()
 {

--- a/gui/initialsettingswizard.h
+++ b/gui/initialsettingswizard.h
@@ -51,6 +51,15 @@ private Q_SLOTS:
     void accept();
     void reject();
     void controlNextButton();
+    #ifdef AVAHI_FOUND
+    void adoptServerSettings(QString ip, QString port);
+    void detectMPDs();
+    #endif
+
+private:
+    #ifdef AVAHI_FOUND
+    QPushButton *discoveryButton;
+    #endif
 };
 
 #endif

--- a/gui/serversettings.cpp
+++ b/gui/serversettings.cpp
@@ -31,6 +31,9 @@
 #include "mpd-interface/mpduser.h"
 #endif
 #include "support/utils.h"
+#ifdef AVAHI_FOUND
+#include "findmpddialog.h"
+#endif
 #include <QDir>
 #include <QComboBox>
 #include <QPushButton>
@@ -119,6 +122,12 @@ ServerSettings::ServerSettings(QWidget *p)
 
     #ifdef Q_OS_MAC
     expandingSpacer->changeSize(0, 0, QSizePolicy::Fixed, QSizePolicy::Fixed);
+    #endif
+
+    #ifdef AVAHI_FOUND
+    discoveryButton = new QPushButton(tr("Discover..."), this);
+    hostLayout->insertWidget(0, discoveryButton);
+    connect(discoveryButton, &QPushButton::clicked, this, &ServerSettings::detectMPDs);
     #endif
 }
 
@@ -336,6 +345,21 @@ void ServerSettings::basicDirChanged()
         basicMusicFolderNoteLabel->setOn(d.isEmpty() || d!=prevBasic.details.dir);
     }
 }
+
+#ifdef AVAHI_FOUND
+void ServerSettings::adoptServerSettings(QString ip, QString p)
+{
+    host->setText(ip);
+    port->setValue(p.toInt());
+}
+
+void ServerSettings::detectMPDs()
+{
+    FindMpdDialog findMpdDlg(this);
+    QObject::connect(&findMpdDlg, &FindMpdDialog::serverChosen, this, &ServerSettings::adoptServerSettings);
+    findMpdDlg.exec();
+}
+#endif
 
 QString ServerSettings::generateName(int ignore) const
 {

--- a/gui/serversettings.h
+++ b/gui/serversettings.h
@@ -28,6 +28,8 @@
 #include "mpd-interface/mpdconnection.h"
 #include "devices/deviceoptions.h"
 
+#include <QPushButton>
+
 class ServerSettings : public QWidget, private Ui::ServerSettings
 {
     Q_OBJECT
@@ -53,11 +55,19 @@ private Q_SLOTS:
     void remove();
     void nameChanged();
     void basicDirChanged();
+    #ifdef AVAHI_FOUND
+    void detectMPDs();
+    void adoptServerSettings(QString ip, QString port);
+    #endif
 
 private:
     void setDetails(const MPDConnectionDetails &details);
     MPDConnectionDetails getDetails() const;
     QString generateName(int ignore=-1) const;
+
+    #ifdef AVAHI_FOUND
+    QPushButton *discoveryButton;
+    #endif
 
 private:
     QList<Collection> collections;


### PR DESCRIPTION
This commit adds automatic avahi service discovery to Cantata. A new
dialog is added to the initial settings wizard and the settings menu
which lets the user choose the correct host configuration for all MPDs
on the network automatically.

To compile this feature the following libraries have to be installed:
*libavahi-common
*libavahi-client

These are included in the following Ubuntu packages:
*libavahi-common-dev
*libavahi-client-dev

Any remaks and suggestions are welcome.

