### PR TITLE
http: make HTTP server support configurable

### DIFF
--- a/gui/serversettings.cpp
+++ b/gui/serversettings.cpp
@@ -116,6 +116,9 @@ ServerSettings::ServerSettings(QWidget *p)
     REMOVE(streamUrl)
     REMOVE(streamUrlNoteLabel)
     #endif
+    #ifndef ENABLE_HTTP_SERVER
+    REMOVE(allowLocalStreaming);
+    #endif
 
     #ifdef Q_OS_MAC
     expandingSpacer->changeSize(0, 0, QSizePolicy::Fixed, QSizePolicy::Fixed);
@@ -178,6 +181,7 @@ void ServerSettings::save()
                     #ifdef ENABLE_HTTP_STREAM_PLAYBACK
                     || c.details.streamUrl!=e.streamUrl
                     #endif
+                    || c.details.allowLocalStreaming!=e.allowLocalStreaming
                     ) {
                     toAdd.append(c);
                 }
@@ -279,6 +283,8 @@ void ServerSettings::add()
         details.port=6600;
         details.hostname=QLatin1String("localhost");
         details.dir=QLatin1String("/var/lib/mpd/music/");
+        // disable local streaming by default
+        details.allowLocalStreaming=false;
         combo->addItem(details.name);
     #ifdef ENABLE_SIMPLE_MPD_SUPPORT
     } else {
@@ -375,6 +381,9 @@ void ServerSettings::setDetails(const MPDConnectionDetails &details)
         #ifdef ENABLE_HTTP_STREAM_PLAYBACK
         streamUrl->setText(details.streamUrl);
         #endif
+        #ifdef ENABLE_HTTP_SERVER
+        allowLocalStreaming->setChecked(details.allowLocalStreaming);
+        #endif
         stackedWidget->setCurrentIndex(0);
     #ifdef ENABLE_SIMPLE_MPD_SUPPORT
     }
@@ -398,6 +407,9 @@ MPDConnectionDetails ServerSettings::getDetails() const
         details.coverName=coverName->text().trimmed();
         #ifdef ENABLE_HTTP_STREAM_PLAYBACK
         details.streamUrl=streamUrl->text().trimmed();
+        #endif
+        #ifdef ENABLE_HTTP_SERVER
+        details.allowLocalStreaming=allowLocalStreaming->checkState() == Qt::Checked;
         #endif
     }
     #ifdef ENABLE_SIMPLE_MPD_SUPPORT

--- a/gui/serversettings.ui
+++ b/gui/serversettings.ui
@@ -163,6 +163,16 @@
          <item row="5" column="1">
           <widget class="LineEdit" name="streamUrl"/>
          </item>
+         <item row="6" column="0" colspan="2">
+          <widget class="QCheckBox" name="allowLocalStreaming">
+           <property name="toolTip">
+            <string>If enabled, you can drag local files into the play queue. For this to work, MPD gets access to those (and only those) local files via HTTP.</string>
+           </property>
+           <property name="text">
+            <string>Allow access to local files</string>
+           </property>
+          </widget>
+         </item>
         </layout>
        </item>
        <item row="2" column="0" colspan="2">

--- a/gui/settings.cpp
+++ b/gui/settings.cpp
@@ -171,6 +171,9 @@ MPDConnectionDetails Settings::connectionDetails(const QString &name)
         details.streamUrl=grp.get("streamUrl", QString());
         #endif
         details.replayGain=grp.get("replayGain", QString());
+        // if the setting hasn't been set before, we set it to true to allow
+        // for easy migration of existing settings
+        details.allowLocalStreaming=grp.get("allowLocalStreaming", true);
     } else {
         details.hostname=mpdDefaults.host;
         details.port=mpdDefaults.port;
@@ -180,6 +183,7 @@ MPDConnectionDetails Settings::connectionDetails(const QString &name)
         #ifdef ENABLE_HTTP_STREAM_PLAYBACK
         details.streamUrl=QString();
         #endif
+        details.allowLocalStreaming=true;
     }
     details.setDirReadable();
     return details;
@@ -695,6 +699,7 @@ void Settings::saveConnectionDetails(const MPDConnectionDetails &v)
     #ifdef ENABLE_HTTP_STREAM_PLAYBACK
     grp.set("streamUrl", v.streamUrl);
     #endif
+    grp.set("allowLocalStreaming", v.allowLocalStreaming);
 }
 
 void Settings::saveCurrentConnection(const QString &v)

--- a/http/httpserver.cpp
+++ b/http/httpserver.cpp
@@ -71,6 +71,12 @@ HttpServer::HttpServer()
     connect(MPDConnection::self(), SIGNAL(ifaceIp(QString)), this, SLOT(ifaceIp(QString)));
 }
 
+bool HttpServer::isAlive() const
+{
+    // started on demand, but only start if allowed
+    return Settings::self()->connectionDetails().allowLocalStreaming;
+}
+
 bool HttpServer::start()
 {
     if (closeTimer) {

--- a/http/httpserver.h
+++ b/http/httpserver.h
@@ -51,7 +51,7 @@ public:
 
     #ifdef ENABLE_HTTP_SERVER
     HttpServer();
-    bool isAlive() const { return true; } // Started on-demamnd!
+    bool isAlive() const; // Started on-demamnd!
     void readConfig();
     QString address() const;
     bool isOurs(const QString &url) const;

--- a/mpd-interface/mpdconnection.h
+++ b/mpd-interface/mpdconnection.h
@@ -162,6 +162,7 @@ struct MPDConnectionDetails {
     QString streamUrl;
     #endif
     QString replayGain;
+    bool allowLocalStreaming;
 };
 
 class MPDConnection : public QObject


### PR DESCRIPTION
This allows to configure the local files streaming option per-connection. It defaults to enabled for existing and disabled for new connections.

[Debian does not like that this feature opens an HTTP socket](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=872704) and would prefer to have this configurable and disabled-by-default. Currently, cantata is built without support for streaming files to MPD on Debian, which I find unfortunate.

This is my first large PR against Cantata. I’m happy to make changes if I did anything not according to your liking.