### PR TITLE
Forked daapd file prefix

### DIFF
--- a/context/songview.cpp
+++ b/context/songview.cpp
@@ -651,7 +651,7 @@ void SongView::loadMetadata()
         tagInfo+=QLatin1String("<tr/>");
     }
     if (MPDConnection::self()->getDetails().dirReadable) {
-        QString path=Utils::getDir(MPDConnection::self()->getDetails().dir+currentSong.filePath());
+        QString path=Utils::getDir(currentSong.filePath(MPDConnection::self()->getDetails().dir));
         tagInfo+=createRow(tr("Filename"), QLatin1String("<a href=\"file://")+path+QLatin1String("\">")+
                                              currentSong.filePath()+QLatin1String("</a>"));
     } else {

--- a/devices/actiondialog.cpp
+++ b/devices/actiondialog.cpp
@@ -570,7 +570,7 @@ void ActionDialog::doNext()
                 performingAction=true;
                 if (copyToDev) {
                     destFile=dev->path()+dev->options().createFilename(currentSong);
-                    currentSong.file=MPDConnection::self()->getDetails().dir+currentSong.filePath();
+                    currentSong.file=currentSong.filePath(MPDConnection::self()->getDetails().dir);
                     dev->addSong(currentSong, overwrite->isChecked(), !copiedCovers.contains(Utils::getDir(destFile)));
                 } else {
                     Song copy=currentSong;

--- a/gui/librarypage.cpp
+++ b/gui/librarypage.cpp
@@ -200,7 +200,7 @@ void LibraryPage::showSongs(const QList<Song> &songs)
     // Filter out non-mpd file songs...
     QList<Song> sngs;
     foreach (const Song &s, songs) {
-        if (!s.file.isEmpty() && !s.file.contains(":/") && !s.file.startsWith('/')) {
+        if (!s.file.isEmpty() && !s.hasProtocolOrIsAbsolute()) {
             sngs.append(s);
         }
     }

--- a/mpd-interface/mpdconnection.h
+++ b/mpd-interface/mpdconnection.h
@@ -231,6 +231,7 @@ public:
     int unmuteVolume() { return unmuteVol; }
     bool isMuted() { return -1!=unmuteVol; }
     bool isMopidy() const { return mopidy; }
+    bool isforkedDaapd() const { return forkedDaapd; }
     void setVolumeFadeDuration(int f) { fadeDuration=f; }
     QString ipAddress() const { return details.isLocal() ? QString() : sock.address(); }
 
@@ -462,6 +463,7 @@ private:
     quint32 songPos; // USe for stop-after-current when we only have 1 songin playqueue!
     int unmuteVol;
     bool mopidy;
+    bool forkedDaapd;
     bool isUpdatingDb;
 
     QPropertyAnimation *volumeFade;

--- a/mpd-interface/song.cpp
+++ b/mpd-interface/song.cpp
@@ -41,6 +41,7 @@
 
 const QString Song::constCddaProtocol=QLatin1String("/[cantata-cdda]/");
 const QString Song::constMopidyLocal=QLatin1String("local:track:");
+const QString Song::constForkedDaapdLocal=QLatin1String("file:");
 
 static QString unknownStr;
 static QString variousArtistsStr;
@@ -124,7 +125,13 @@ QString Song::decodePath(const QString &file, bool cdda)
     if (cdda) {
         return QString(file).replace("/", "_").replace(":", "_");
     }
-    return file.startsWith(constMopidyLocal) ? QUrl::fromPercentEncoding(file.mid(constMopidyLocal.length()).toLatin1()) : file;
+    if (file.startsWith(constMopidyLocal)) {
+        return QUrl::fromPercentEncoding(file.mid(constMopidyLocal.length()).toLatin1());
+    }
+    if (file.startsWith(constForkedDaapdLocal)) {
+        return file.mid(constForkedDaapdLocal.length());
+    }
+    return file;
 }
 
 QString Song::encodePath(const QString &file)

--- a/mpd-interface/song.cpp
+++ b/mpd-interface/song.cpp
@@ -728,6 +728,16 @@ QString Song::basicArtist() const
     return artist;
 }
 
+QString Song::filePath(const QString &base) const
+{
+    QString fileName=filePath();
+    bool haveAbsPath=fileName.startsWith("/"); // Utils::constDirSep
+    if (!haveAbsPath) {
+        return QString(base+fileName);
+    }
+    return fileName;
+}
+
 QString Song::describe(bool withMarkup) const
 {
     QString albumText=album.isEmpty() ? name() : displayAlbum(album, Song::albumYear(*this));

--- a/mpd-interface/song.h
+++ b/mpd-interface/song.h
@@ -209,6 +209,7 @@ struct Song
     bool isStandardStream() const { return Stream==type && !isDlnaStream(); }
     bool isDlnaStream() const { return Stream==type && !albumArtist().isEmpty() && !album.isEmpty() && track>0; }
     bool isNonMPD() const { return isStream() || OnlineSvrTrack==type || Cdda==type || (!file.isEmpty() && file.startsWith(Utils::constDirSep)); }
+    bool hasProtocolOrIsAbsolute() const { return !file.isEmpty() && (file.startsWith(Utils::constDirSep) || (!file.startsWith(constForkedDaapdLocal) && file.contains(":/")));}
     bool isCantataStream() const { return CantataStream==type; }
     bool isCdda() const { return Cdda==type; }
     QString albumKey() const;

--- a/mpd-interface/song.h
+++ b/mpd-interface/song.h
@@ -216,6 +216,7 @@ struct Song
     bool isFromCue() const { return CueFile::isCue(file); }
     QString basicArtist() const;
     QString filePath() const { return decodePath(file, isCdda()); }
+    QString filePath(const QString &base) const;
     QString displayAlbum(bool useComp=true) const { return displayAlbum(useComp ? albumName() : album, year); }
     QString describe(bool withMarkup=false) const;
     bool useComposer() const;

--- a/mpd-interface/song.h
+++ b/mpd-interface/song.h
@@ -121,6 +121,7 @@ struct Song
     static void initTranslations();
     static const QString constCddaProtocol;
     static const QString constMopidyLocal;
+    static const QString constForkedDaapdLocal;
     static void storeAlbumYear(const Song &s);
     static int albumYear(const Song &s);
     static void sortViaType(QList<Song> &songs);

--- a/replaygain/rgdialog.cpp
+++ b/replaygain/rgdialog.cpp
@@ -304,7 +304,7 @@ void RgDialog::createScanner(const QList<int> &indexes)
 {
     QMap<int, QString> fileMap;
     foreach (int i, indexes) {
-        fileMap[i]=base+origSongs.at(i).filePath();
+        fileMap[i]=origSongs.at(i).filePath(base);
     }
 
     AlbumScanner *s=new AlbumScanner(fileMap);
@@ -379,8 +379,8 @@ bool RgDialog::saveTags()
     QMap<int, Tags::ReplayGain>::ConstIterator end=tagsToSave.constEnd();
 
     for (; it!=end; ++it) {
-        QString filePath=origSongs.at(it.key()).filePath();
-        switch (Tags::updateReplaygain(base+filePath, it.value())) {
+        QString filePath=origSongs.at(it.key()).filePath(base);
+        switch (Tags::updateReplaygain(filePath, it.value())) {
         case Tags::Update_Failed:
             failed.append(filePath);
             break;

--- a/tags/tageditor.cpp
+++ b/tags/tageditor.cpp
@@ -516,7 +516,7 @@ void TagEditor::readComments()
             continue;
         }
         Song song=original.at(i);
-        QString comment=Tags::readComment(baseDir+song.file);
+        QString comment=Tags::readComment(song.filePath(baseDir));
         if (!comment.isEmpty()) {
             song.setComment(comment);
             original.replace(i, song);
@@ -761,7 +761,7 @@ void TagEditor::readRatings()
                 QCoreApplication::processEvents(QEventLoop::ExcludeUserInputEvents);
             }
             Song s=edited.at(i);
-            int r=Tags::readRating(baseDir+s.file);
+            int r=Tags::readRating(s.filePath(baseDir));
             if (r>=0 && r<=Song::Rating_Max && s.rating!=r) {
                 s.rating=r;
                 edited.replace(i, s);
@@ -779,7 +779,7 @@ void TagEditor::readRatings()
         }
     } else {
         Song s=edited.at(currentSongIndex);
-        int r=Tags::readRating(baseDir+s.file);
+        int r=Tags::readRating(s.filePath(baseDir));
         if (r>=0 && r<=Song::Rating_Max && s.rating!=r) {
             s.rating=r;
             edited.replace(currentSongIndex, s);
@@ -830,7 +830,7 @@ void TagEditor::writeRatings()
             }
             Song s=edited.at(i);
             if (s.rating<=Song::Rating_Max) {
-                Tags::Update status=Tags::updateRating(baseDir+s.file, s.rating);
+                Tags::Update status=Tags::updateRating(s.filePath(baseDir), s.rating);
                 if (Tags::Update_Failed==status || Tags::Update_BadFile==status){
                     failed.append(s.file);
                 }
@@ -843,7 +843,7 @@ void TagEditor::writeRatings()
     } else {
         Song s=edited.at(currentSongIndex);
         if (s.rating<=Song::Rating_Max) {
-            Tags::Update status=Tags::updateRating(baseDir+s.file, s.rating);
+            Tags::Update status=Tags::updateRating(s.filePath(baseDir), s.rating);
             if (Tags::Update_Failed==status || Tags::Update_BadFile==status){
                 MessageBox::error(this, tr("Failed to write rating to music file!"));
             }
@@ -1168,9 +1168,10 @@ bool TagEditor::applyUpdates()
         }
 
         QString file=orig.filePath();
+        QString afile=orig.filePath(baseDir);
         splitGenres(orig);
         splitGenres(edit);
-        switch(Tags::update(baseDir+file, orig, edit, -1, commentSupport)) {
+        switch(Tags::update(afile, orig, edit, -1, commentSupport)) {
         case Tags::Update_Modified:
             edit.setComment(QString());
             #ifdef ENABLE_DEVICES_SUPPORT

--- a/widgets/playqueueview.cpp
+++ b/widgets/playqueueview.cpp
@@ -347,7 +347,7 @@ QList<Song> PlayQueueView::selectedSongs() const
 
     foreach (const QModelIndex &idx, selected) {
         Song song=idx.data(Cantata::Role_Song).value<Song>();
-        if (!song.file.isEmpty() && !song.file.contains(":/") && !song.file.startsWith('/')) {
+        if (!song.file.isEmpty() && !song.hasProtocolOrIsAbsolute()) {
             songs.append(song);
         }
     }

--- a/widgets/songdialog.cpp
+++ b/widgets/songdialog.cpp
@@ -40,10 +40,11 @@ bool SongDialog::songsOk(const QList<Song> &songs, const QString &base, bool isM
     QWidget *wid=isVisible() ? this : parentWidget();
     int checked=0;
     foreach (const Song &s, songs) {
-        QString file=s.filePath();
-        DBUG << "Checking dir:" << base << " song:" << file << " file:" << QString(base+file);
-        if (!QFile::exists(base+file)) {
-            DBUG << QString(base+file) << "does not exist";
+        const QString sfile=s.filePath();
+        const QString file=s.filePath(base);
+        DBUG << "Checking dir:" << base << " song:" << sfile << " file:" << file;
+        if (!QFile::exists(file)) {
+            DBUG << QString(file) << "does not exist";
             if (isMpd) {
                 MessageBox::error(wid, tr("Cannot access song files!\n\n"
                                             "Please check Cantata's \"Music folder\" setting, and MPD's \"music_directory\" setting."));


### PR DESCRIPTION
forked-daapd(8) sends absolute path names with a prefix of `file:`. E.g.: `file:/srv/music/Vivaldi/xx.mp3`.
This is handled by the first patch.

After fixing this, I found that downloading covers now worked, but other things -- like editing tag information and the file link on the information page -- did not. This is handled by the second patch.

Some PlayQueue actions use a test for nonMPD files by looking for ":/", which obviously fails for forked-daap. This is fixed by the third patch. 