### PR TITLE
Proposal for MPD server detection

### DIFF
--- a/models/playqueuemodel.cpp
+++ b/models/playqueuemodel.cpp
@@ -878,7 +878,8 @@ void PlayQueueModel::update(const QList<Song> &songList, bool isComplete)
     }
 
     // If we have too many changes UI can hang, so it is sometimes better just to do a complete reset!
-    if (isComplete && songs.count()>MPDConnection::constMaxPqChanges) {
+    if (isComplete && (songs.count()>MPDConnection::constMaxPqChanges
+                       || !MPDConnection::self()->isPlayQueueIdValid())) {
         songs.clear();
     }
 

--- a/mpd-interface/mpdconnection.cpp
+++ b/mpd-interface/mpdconnection.cpp
@@ -2065,7 +2065,7 @@ bool MPDConnection::recursivelyListDir(const QString &dir, QList<Song> &songs)
     }
 
     Response response=sendCommand(topLevel
-                                    ? serverInfo.topLevelLsinfo()
+                                    ? serverInfo.getTopLevelLsinfo()
                                     : ("lsinfo "+encodeName(dir)));
     if (response.ok) {
         QStringList subDirs;
@@ -2498,7 +2498,7 @@ void MPDServerInfo::detect(void) {
                 && 0==stats.uptime && 0==stats.playtime && 0==stats.dbPlaytime
                 && 0==stats.dbUpdate) {
                 setServerType(Mopidy);
-                theServerName = "Mopidy";
+                serverName = "Mopidy";
             }
         }
     }
@@ -2518,7 +2518,7 @@ void MPDServerInfo::detect(void) {
                 }
                 if (match) {
                     setServerType(rp.serverType);
-                    theServerName = rp.name;
+                    serverName = rp.name;
                     break;
                 }
             }
@@ -2529,17 +2529,17 @@ void MPDServerInfo::detect(void) {
 
     if (isUndetermined()) {
         setServerType(Unknown);
-        theServerName = "unknown";
+        serverName = "unknown";
     }
 
-    DBUG << "detected serverType: " << serverName() << "(" << serverType() << ")";
+    DBUG << "detected serverType: " << getServerName() << "(" << getServerType() << ")";
 
     if (isMopidy()) {
-        theTopLevelLsinfo = "lsinfo \"Local media\"";
+        topLevelLsinfo = "lsinfo \"Local media\"";
     }
 
     if (isForkedDaapd()) {
-        theTopLevelLsinfo = "lsinfo file:";
+        topLevelLsinfo = "lsinfo file:";
 
         QByteArray message = "sendmessage rating \"";
         message += "rating ";                           // sticker name
@@ -2553,6 +2553,6 @@ void MPDServerInfo::detect(void) {
 
 void MPDServerInfo::reset(void) {
     setServerType(MPDServerInfo::Undetermined);
-    theServerName = "undetermined";
-    theTopLevelLsinfo = "lsinfo";
+    serverName = "undetermined";
+    topLevelLsinfo = "lsinfo";
 }

--- a/mpd-interface/mpdconnection.cpp
+++ b/mpd-interface/mpdconnection.cpp
@@ -595,6 +595,7 @@ void MPDConnection::setDetails(const MPDConnectionDetails &d)
             if (replaygainSupported() && !details.replayGain.isEmpty()) {
                 sendCommand("replay_gain_mode "+details.replayGain.toLatin1());
             }
+            serverInfo.detect();
             getStatus();
             getStats();
             getUrlHandlers();
@@ -1397,7 +1398,6 @@ void MPDConnection::clearStopAfter()
 
 void MPDConnection::getStats()
 {
-    serverInfo.detect();
     Response response=sendCommand("stats");
     if (response.ok) {
         MPDStatsValues stats=MPDParseUtils::parseStats(response.data);

--- a/mpd-interface/mpdconnection.cpp
+++ b/mpd-interface/mpdconnection.cpp
@@ -1048,7 +1048,7 @@ void MPDConnection::playListChanges()
     QByteArray data = "plchangesposid "+quote(lastUpdatePlayQueueVersion);
     Response status=sendCommand("status"); // We need an updated status so as to detect deletes at end of list...
     Response response=sendCommand(data, false);
-    if (response.ok && status.ok) {
+    if (response.ok && status.ok && isPlayQueueIdValid()) {
         MPDStatusValues sv=MPDParseUtils::parseStatus(status.data);
         lastUpdatePlayQueueVersion=lastStatusPlayQueueVersion=sv.playlist;
         emitStatusUpdated(sv);
@@ -2532,7 +2532,7 @@ void MPDServerInfo::detect(void) {
         serverName = "unknown";
     }
 
-    DBUG << "detected serverType: " << getServerName() << "(" << getServerType() << ")";
+    DBUG << "detected serverType:" << getServerName() << "(" << getServerType() << ")";
 
     if (isMopidy()) {
         topLevelLsinfo = "lsinfo \"Local media\"";

--- a/mpd-interface/mpdconnection.h
+++ b/mpd-interface/mpdconnection.h
@@ -191,6 +191,7 @@ public:
     bool isMpd(void) const { return serverType == Mpd; }
     bool isMopidy(void) const { return serverType == Mopidy; }
     bool isForkedDaapd(void) const { return serverType == ForkedDaapd; }
+    bool isPlayQueueIdValid(void) const { return serverType != ForkedDaapd; }
 
     const QString &getServerName(void) const { return serverName;}
     const QByteArray &getTopLevelLsinfo(void) const { return topLevelLsinfo; }
@@ -281,6 +282,7 @@ public:
     bool isMpd(void) const { return serverInfo.isMpd(); }
     bool isMopidy(void) const { return serverInfo.isMopidy(); }
     bool isForkedDaapd(void) const { return serverInfo.isForkedDaapd(); }
+    bool isPlayQueueIdValid(void) const { return serverInfo.isPlayQueueIdValid(); }
     void setVolumeFadeDuration(int f) { fadeDuration=f; }
     QString ipAddress() const { return details.isLocal() ? QString() : sock.address(); }
 

--- a/mpd-interface/mpdconnection.h
+++ b/mpd-interface/mpdconnection.h
@@ -196,7 +196,7 @@ public:
     const QByteArray &getTopLevelLsinfo(void) const { return topLevelLsinfo; }
 
 private:
-    void setServerType(ServerType serverType) { serverType = serverType; }
+    void setServerType(ServerType newServerType) { serverType = newServerType; }
 
     ServerType serverType;
     QString serverName;

--- a/mpd-interface/mpdconnection.h
+++ b/mpd-interface/mpdconnection.h
@@ -166,6 +166,53 @@ struct MPDConnectionDetails {
     bool autoUpdate;
 };
 
+class MPDServerInfo {
+public:
+    enum ServerType {
+        Undetermined,
+        Mpd,
+        Mopidy,
+        ForkedDaapd,
+        Unknown
+    };
+
+    MPDServerInfo() {
+        reset();
+        lsinfoCommand = "lsinfo \"mpd-client://cantata/";
+        lsinfoCommand += PACKAGE_VERSION_STRING;
+        lsinfoCommand += "\"";
+    };
+
+    void reset(void);
+    void detect(void);
+
+    ServerType serverType(void) const { return theServerType;}
+    bool isUndetermined(void) const { return theServerType == Undetermined; }
+    bool isMpd(void) const { return theServerType == Mpd; }
+    bool isMopidy(void) const { return theServerType == Mopidy; }
+    bool isForkedDaapd(void) const { return theServerType == ForkedDaapd; }
+
+    const QString &serverName(void) const { return theServerName;}
+    const QByteArray &topLevelLsinfo(void) const { return theTopLevelLsinfo; }
+
+private:
+    void setServerType(ServerType serverType) { theServerType = serverType; }
+
+    ServerType theServerType;
+    QString theServerName;
+    QByteArray theTopLevelLsinfo;
+
+    struct ResponseParameter {
+        QByteArray response;
+        bool isSubstring;
+        ServerType serverType;
+        QString name;
+    };
+
+    QByteArray lsinfoCommand;
+    static ResponseParameter lsinfoResponseParameters[];
+};
+
 class MPDConnection : public QObject
 {
     Q_OBJECT
@@ -215,7 +262,7 @@ public:
     const MPDConnectionDetails & getDetails() const { return details; }
     void setDirReadable() { details.setDirReadable(); }
     bool isConnected() const { return State_Connected==state; }
-    bool canUsePriority() const { return ver>=CANTATA_MAKE_VERSION(0, 17, 0) && !mopidy; }
+    bool canUsePriority() const { return ver>=CANTATA_MAKE_VERSION(0, 17, 0) && isMpd(); }
     const QSet<QString> & urlHandlers() const { return handlers; }
     const QSet<QString> & tags() const { return tagTypes; }
     bool composerTagSupported() const { return tagTypes.contains(QLatin1String("Composer")); }
@@ -231,8 +278,9 @@ public:
     static bool isPlaylist(const QString &file);
     int unmuteVolume() { return unmuteVol; }
     bool isMuted() { return -1!=unmuteVol; }
-    bool isMopidy() const { return mopidy; }
-    bool isforkedDaapd() const { return forkedDaapd; }
+    bool isMpd(void) const { return serverInfo.isMpd(); }
+    bool isMopidy(void) const { return serverInfo.isMopidy(); }
+    bool isForkedDaapd(void) const { return serverInfo.isForkedDaapd(); }
     void setVolumeFadeDuration(int f) { fadeDuration=f; }
     QString ipAddress() const { return details.isLocal() ? QString() : sock.address(); }
 
@@ -464,14 +512,13 @@ private:
     qint32 currentSongId;
     quint32 songPos; // USe for stop-after-current when we only have 1 songin playqueue!
     int unmuteVol;
-    bool mopidy;
-    bool forkedDaapd;
+    friend class MPDServerInfo;
+    MPDServerInfo serverInfo;
     bool isUpdatingDb;
 
     QPropertyAnimation *volumeFade;
     int fadeDuration;
     int restoreVolume;
 };
-
 
 #endif

--- a/mpd-interface/mpdconnection.h
+++ b/mpd-interface/mpdconnection.h
@@ -186,21 +186,21 @@ public:
     void reset(void);
     void detect(void);
 
-    ServerType serverType(void) const { return theServerType;}
-    bool isUndetermined(void) const { return theServerType == Undetermined; }
-    bool isMpd(void) const { return theServerType == Mpd; }
-    bool isMopidy(void) const { return theServerType == Mopidy; }
-    bool isForkedDaapd(void) const { return theServerType == ForkedDaapd; }
+    ServerType getServerType(void) const { return serverType;}
+    bool isUndetermined(void) const { return serverType == Undetermined; }
+    bool isMpd(void) const { return serverType == Mpd; }
+    bool isMopidy(void) const { return serverType == Mopidy; }
+    bool isForkedDaapd(void) const { return serverType == ForkedDaapd; }
 
-    const QString &serverName(void) const { return theServerName;}
-    const QByteArray &topLevelLsinfo(void) const { return theTopLevelLsinfo; }
+    const QString &getServerName(void) const { return serverName;}
+    const QByteArray &getTopLevelLsinfo(void) const { return topLevelLsinfo; }
 
 private:
-    void setServerType(ServerType serverType) { theServerType = serverType; }
+    void setServerType(ServerType serverType) { serverType = serverType; }
 
-    ServerType theServerType;
-    QString theServerName;
-    QByteArray theTopLevelLsinfo;
+    ServerType serverType;
+    QString serverName;
+    QByteArray topLevelLsinfo;
 
     struct ResponseParameter {
         QByteArray response;

--- a/tags/trackorganiser.cpp
+++ b/tags/trackorganiser.cpp
@@ -426,7 +426,7 @@ void TrackOrganiser::renameFile()
             if (s.file.startsWith(Song::constMopidyLocal)) {
                 origPath=to.file;
                 to.file=Song::encodePath(to.file);
-            } else if (MPDConnection::self()->isforkedDaapd()) {
+            } else if (MPDConnection::self()->isForkedDaapd()) {
                 to.file=Song::constForkedDaapdLocal + dest;
             } else {
                 to.file=modified;


### PR DESCRIPTION
So this is the first draft of a server detection proposal. I have put everything in two places for easier review.

The response to`lsinfo` with a specific invalid URI provides the information to reliably detect MPD and forked-daapd. The invalid URI is designed to provide a user agent identification.

I think hiding this stuff in in its own class is better than expanding getStats(), but it must be integrated into MPDConnection in order to use sendCommand() which is private.

The rating problem is also addressed by sending a message to the rating channel. This is the solution I will propose to the forked-daapd team.

Let me know what you think and I will tweak this to your wishes.
