### PR TITLE
Fix overlapping checkboxes

### DIFF
--- a/gui/interfacesettings.ui
+++ b/gui/interfacesettings.ui
@@ -391,7 +391,7 @@
          </property>
         </widget>
        </item>
-       <item row="3" column="0" colspan="2">
+       <item row="2" column="0">
         <widget class="QCheckBox" name="showTechnicalInfo">
          <property name="text">
           <string>Show technical info</string>


### PR DESCRIPTION
The checkboxes in Preferences->Interface->Toolbar were overlapping since
commit c30650adc.