### PR TITLE
Spelling fixes

### DIFF
--- a/gui/initialsettingswizard.ui
+++ b/gui/initialsettingswizard.ui
@@ -169,7 +169,7 @@
               </sizepolicy>
              </property>
              <property name="text">
-              <string>&lt;i&gt;Select this option if your music collection is shared between users, your MPD instance is running on another machine, you already have a personal MPD setup, or you wish to enable access from other clients (e.g. MPDroid). If you select this option then Cantata itself cannot control the starting and stopping of the MPD server. You will therfore need to ensure that MPD is already configured and running.&lt;/i&gt;</string>
+              <string>&lt;i&gt;Select this option if your music collection is shared between users, your MPD instance is running on another machine, you already have a personal MPD setup, or you wish to enable access from other clients (e.g. MPDroid). If you select this option then Cantata itself cannot control the starting and stopping of the MPD server. You will therefore need to ensure that MPD is already configured and running.&lt;/i&gt;</string>
              </property>
              <property name="alignment">
               <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -1145,7 +1145,7 @@ void MainWindow::showAboutDialog()
 bool MainWindow::canClose()
 {
     if (onlinePage->isDownloading() &&
-            MessageBox::No==MessageBox::warningYesNo(this, tr("A Podcast is currently being downloaded\n\nQuiting now will abort the download."),
+            MessageBox::No==MessageBox::warningYesNo(this, tr("A Podcast is currently being downloaded\n\nQuitting now will abort the download."),
                                                      QString(), GuiItem(tr("Abort download and quit")), GuiItem("Do not quit just yet"))) {
         return false;
     }

--- a/mpd-interface/song.cpp
+++ b/mpd-interface/song.cpp
@@ -562,7 +562,7 @@ QString Song::toolTip() const
         addField(QObject::tr("Year"), QString::number(year), toolTip);
     }
     if (origYear>0) {
-        addField(QObject::tr("Orignal Year"), QString::number(origYear), toolTip);
+        addField(QObject::tr("Original Year"), QString::number(origYear), toolTip);
     }
     if (time>0) {
         addField(QObject::tr("Length"), Utils::formatTime(time, true), toolTip);

--- a/translations/blank.ts
+++ b/translations/blank.ts
@@ -5658,7 +5658,7 @@ width x height</comment>
     </message>
     <message>
         <location filename="../mpd-interface/song.cpp" line="565"/>
-        <source>Orignal Year</source>
+        <source>Original Year</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/blank.ts
+++ b/translations/blank.ts
@@ -3361,7 +3361,7 @@ If this search does find new lyrics, these will still be associated with the ori
         <location filename="../gui/mainwindow.cpp" line="1128"/>
         <source>A Podcast is currently being downloaded
 
-Quiting now will abort the download.</source>
+Quitting now will abort the download.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/blank.ts
+++ b/translations/blank.ts
@@ -2003,7 +2003,7 @@ This cannot be undone.</source>
     </message>
     <message>
         <location filename="../gui/initialsettingswizard.ui" line="172"/>
-        <source>&lt;i&gt;Select this option if your music collection is shared between users, your MPD instance is running on another machine, you already have a personal MPD setup, or you wish to enable access from other clients (e.g. MPDroid). If you select this option then Cantata itself cannot control the starting and stopping of the MPD server. You will therfore need to ensure that MPD is already configured and running.&lt;/i&gt;</source>
+        <source>&lt;i&gt;Select this option if your music collection is shared between users, your MPD instance is running on another machine, you already have a personal MPD setup, or you wish to enable access from other clients (e.g. MPDroid). If you select this option then Cantata itself cannot control the starting and stopping of the MPD server. You will therefore need to ensure that MPD is already configured and running.&lt;/i&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/cantata_cs.ts
+++ b/translations/cantata_cs.ts
@@ -4401,7 +4401,7 @@ i18n: ectx: property (text), widget (QRadioButton, advanced)
         <translation type="vanished">Standardní nastavení pro více uživatelů/server</translation>
     </message>
     <message>
-        <source>&lt;i&gt;Select this option if your music collection is shared between users, your MPD instance is running on another machine, you already have a personal MPD setup, or you wish to enable access from other clients (e.g. MPDroid). If you select this option then Cantata itself cannot control the starting and stopping of the MPD server. You will therfore need to ensure that MPD is already configured and running.&lt;/i&gt;</source>
+        <source>&lt;i&gt;Select this option if your music collection is shared between users, your MPD instance is running on another machine, you already have a personal MPD setup, or you wish to enable access from other clients (e.g. MPDroid). If you select this option then Cantata itself cannot control the starting and stopping of the MPD server. You will therefore need to ensure that MPD is already configured and running.&lt;/i&gt;</source>
         <extracomment>i18n: file: gui/initialsettingswizard.ui:172
 i18n: ectx: property (text), widget (BuddyLabel, label_10)
 </extracomment>
@@ -8317,7 +8317,7 @@ Tento krok nelze vrátit zpět.</translation>
     </message>
     <message>
         <location filename="../gui/initialsettingswizard.ui" line="172"/>
-        <source>&lt;i&gt;Select this option if your music collection is shared between users, your MPD instance is running on another machine, you already have a personal MPD setup, or you wish to enable access from other clients (e.g. MPDroid). If you select this option then Cantata itself cannot control the starting and stopping of the MPD server. You will therfore need to ensure that MPD is already configured and running.&lt;/i&gt;</source>
+        <source>&lt;i&gt;Select this option if your music collection is shared between users, your MPD instance is running on another machine, you already have a personal MPD setup, or you wish to enable access from other clients (e.g. MPDroid). If you select this option then Cantata itself cannot control the starting and stopping of the MPD server. You will therefore need to ensure that MPD is already configured and running.&lt;/i&gt;</source>
         <translation>&lt;i&gt;Tuto volbu vyberte v případě, že vaše sbírka je sdílena mezi uživateli, vaše instance MPD běží na jiném stroji, když již máte osobní nastavení MPD, nebo chcete povolit přístup z jiných klientů (např. MPDroid). Pokud vyberete tuto volbu, Cantata sama nedokáže řídit spouštění a zastavování serveru MPD. Z toho důvodu budete muset zajistit, aby MPD bylo již nastaveno a běželo.&lt;/i&gt;</translation>
     </message>
     <message>

--- a/translations/cantata_cs.ts
+++ b/translations/cantata_cs.ts
@@ -2102,7 +2102,7 @@ i18n: ectx: property (text), widget (QPushButton, connectButton)
     <message>
         <source>A Podcast is currently being downloaded
 
-Quiting now will abort the download.</source>
+Quitting now will abort the download.</source>
         <translation type="vanished">Zvukový záznam se nyní stahují.
 
 Pokud bude program ukončen nyní, bude stahování zrušeno.</translation>
@@ -9711,7 +9711,7 @@ Pokud toto vyhledávání nenalezne nová slova, tato pořád budou spojena s p�
         <location filename="../gui/mainwindow.cpp" line="1128"/>
         <source>A Podcast is currently being downloaded
 
-Quiting now will abort the download.</source>
+Quitting now will abort the download.</source>
         <translation>Zvukový záznam se nyní stahují.
 
 Pokud bude program ukončen nyní, bude stahování zrušeno.</translation>

--- a/translations/cantata_cs.ts
+++ b/translations/cantata_cs.ts
@@ -12201,7 +12201,7 @@ width x height</comment>
     </message>
     <message>
         <location filename="../mpd-interface/song.cpp" line="565"/>
-        <source>Orignal Year</source>
+        <source>Original Year</source>
         <translation>Původní rok</translation>
     </message>
     <message>

--- a/translations/cantata_de.ts
+++ b/translations/cantata_de.ts
@@ -7572,7 +7572,7 @@ Wenn die Suche einen neuen Liedtext findet, dann wird dieser mit dem ursprüngli
         <location filename="../gui/mainwindow.cpp" line="1128"/>
         <source>A Podcast is currently being downloaded
 
-Quiting now will abort the download.</source>
+Quitting now will abort the download.</source>
         <translation>Es wird gerade ein Podcast heruntergeladen.
 
 Wenn du jetzt das Programm beendest, wird der Download abgebrochen.</translation>

--- a/translations/cantata_de.ts
+++ b/translations/cantata_de.ts
@@ -6200,7 +6200,7 @@ Dies kann nicht rückgängig gemacht werden.</translation>
     </message>
     <message>
         <location filename="../gui/initialsettingswizard.ui" line="172"/>
-        <source>&lt;i&gt;Select this option if your music collection is shared between users, your MPD instance is running on another machine, you already have a personal MPD setup, or you wish to enable access from other clients (e.g. MPDroid). If you select this option then Cantata itself cannot control the starting and stopping of the MPD server. You will therfore need to ensure that MPD is already configured and running.&lt;/i&gt;</source>
+        <source>&lt;i&gt;Select this option if your music collection is shared between users, your MPD instance is running on another machine, you already have a personal MPD setup, or you wish to enable access from other clients (e.g. MPDroid). If you select this option then Cantata itself cannot control the starting and stopping of the MPD server. You will therefore need to ensure that MPD is already configured and running.&lt;/i&gt;</source>
         <translation>&lt;i&gt;Wähle diese Option, wenn deine Musiksammlung zwischen Benutzern geteilt wird, deine MPD-Instanz auf einem anderen Rechner läuft, du bereits eine persönliche MPD-Konfiguration eingerichtet hast oder du den Zugriff von anderen Clients (z. B: MPDroid) ermöglichen möchtest. Wenn du diese Option wählst, kann Cantata selbst den MPD-Server nicht starten und stoppen. Du musst daher sicherstellen, dass MPD bereits eingerichtet ist und läuft.&lt;/i&gt;</translation>
     </message>
     <message>

--- a/translations/cantata_de.ts
+++ b/translations/cantata_de.ts
@@ -10032,7 +10032,7 @@ width x height</comment>
     </message>
     <message>
         <location filename="../mpd-interface/song.cpp" line="565"/>
-        <source>Orignal Year</source>
+        <source>Original Year</source>
         <translation>Original-Jahr</translation>
     </message>
     <message>

--- a/translations/cantata_en_GB.ts
+++ b/translations/cantata_en_GB.ts
@@ -2093,7 +2093,7 @@ This cannot be undone.</source>
     </message>
     <message>
         <location filename="../gui/initialsettingswizard.ui" line="172"/>
-        <source>&lt;i&gt;Select this option if your music collection is shared between users, your MPD instance is running on another machine, you already have a personal MPD setup, or you wish to enable access from other clients (e.g. MPDroid). If you select this option then Cantata itself cannot control the starting and stopping of the MPD server. You will therfore need to ensure that MPD is already configured and running.&lt;/i&gt;</source>
+        <source>&lt;i&gt;Select this option if your music collection is shared between users, your MPD instance is running on another machine, you already have a personal MPD setup, or you wish to enable access from other clients (e.g. MPDroid). If you select this option then Cantata itself cannot control the starting and stopping of the MPD server. You will therefore need to ensure that MPD is already configured and running.&lt;/i&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/cantata_en_GB.ts
+++ b/translations/cantata_en_GB.ts
@@ -3451,7 +3451,7 @@ If this search does find new lyrics, these will still be associated with the ori
         <location filename="../gui/mainwindow.cpp" line="1128"/>
         <source>A Podcast is currently being downloaded
 
-Quiting now will abort the download.</source>
+Quitting now will abort the download.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/cantata_en_GB.ts
+++ b/translations/cantata_en_GB.ts
@@ -5759,7 +5759,7 @@ width x height</comment>
     </message>
     <message>
         <location filename="../mpd-interface/song.cpp" line="565"/>
-        <source>Orignal Year</source>
+        <source>Original Year</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/cantata_es.ts
+++ b/translations/cantata_es.ts
@@ -8261,7 +8261,7 @@ Si está búsqueda ofrece letras nuevas, seguirán asociadas al título de la ca
         <location filename="../gui/mainwindow.cpp" line="1128"/>
         <source>A Podcast is currently being downloaded
 
-Quiting now will abort the download.</source>
+Quitting now will abort the download.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/cantata_es.ts
+++ b/translations/cantata_es.ts
@@ -6889,7 +6889,7 @@ This cannot be undone.</source>
     </message>
     <message>
         <location filename="../gui/initialsettingswizard.ui" line="172"/>
-        <source>&lt;i&gt;Select this option if your music collection is shared between users, your MPD instance is running on another machine, you already have a personal MPD setup, or you wish to enable access from other clients (e.g. MPDroid). If you select this option then Cantata itself cannot control the starting and stopping of the MPD server. You will therfore need to ensure that MPD is already configured and running.&lt;/i&gt;</source>
+        <source>&lt;i&gt;Select this option if your music collection is shared between users, your MPD instance is running on another machine, you already have a personal MPD setup, or you wish to enable access from other clients (e.g. MPDroid). If you select this option then Cantata itself cannot control the starting and stopping of the MPD server. You will therefore need to ensure that MPD is already configured and running.&lt;/i&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/cantata_es.ts
+++ b/translations/cantata_es.ts
@@ -10712,7 +10712,7 @@ width x height</comment>
     </message>
     <message>
         <location filename="../mpd-interface/song.cpp" line="565"/>
-        <source>Orignal Year</source>
+        <source>Original Year</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/cantata_fr.ts
+++ b/translations/cantata_fr.ts
@@ -11063,7 +11063,7 @@ width x height</comment>
     </message>
     <message>
         <location filename="../mpd-interface/song.cpp" line="565"/>
-        <source>Orignal Year</source>
+        <source>Original Year</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/cantata_fr.ts
+++ b/translations/cantata_fr.ts
@@ -1886,7 +1886,7 @@ i18n: ectx: property (text), widget (QPushButton, connectButton)
     <message>
         <source>A Podcast is currently being downloaded
 
-Quiting now will abort the download.</source>
+Quitting now will abort the download.</source>
         <translation type="vanished">Un podcast est actuellement en téléchargement
 
 Le téléchargement sera abandonné si vous quittez maintenant.</translation>
@@ -8606,7 +8606,7 @@ Si cette recherche donne de nouveaux résultats, ils seront toujours associés a
         <location filename="../gui/mainwindow.cpp" line="1128"/>
         <source>A Podcast is currently being downloaded
 
-Quiting now will abort the download.</source>
+Quitting now will abort the download.</source>
         <translation type="unfinished">Un podcast est actuellement en téléchargement
 
 Le téléchargement sera abandonné si vous quittez maintenant.</translation>

--- a/translations/cantata_fr.ts
+++ b/translations/cantata_fr.ts
@@ -7224,7 +7224,7 @@ Cette action est définitive.</translation>
     </message>
     <message>
         <location filename="../gui/initialsettingswizard.ui" line="172"/>
-        <source>&lt;i&gt;Select this option if your music collection is shared between users, your MPD instance is running on another machine, you already have a personal MPD setup, or you wish to enable access from other clients (e.g. MPDroid). If you select this option then Cantata itself cannot control the starting and stopping of the MPD server. You will therfore need to ensure that MPD is already configured and running.&lt;/i&gt;</source>
+        <source>&lt;i&gt;Select this option if your music collection is shared between users, your MPD instance is running on another machine, you already have a personal MPD setup, or you wish to enable access from other clients (e.g. MPDroid). If you select this option then Cantata itself cannot control the starting and stopping of the MPD server. You will therefore need to ensure that MPD is already configured and running.&lt;/i&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/cantata_hu.ts
+++ b/translations/cantata_hu.ts
@@ -7719,7 +7719,7 @@ Ezt nem lehet visszavonni!</translation>
     </message>
     <message>
         <location filename="../gui/initialsettingswizard.ui" line="172"/>
-        <source>&lt;i&gt;Select this option if your music collection is shared between users, your MPD instance is running on another machine, you already have a personal MPD setup, or you wish to enable access from other clients (e.g. MPDroid). If you select this option then Cantata itself cannot control the starting and stopping of the MPD server. You will therfore need to ensure that MPD is already configured and running.&lt;/i&gt;</source>
+        <source>&lt;i&gt;Select this option if your music collection is shared between users, your MPD instance is running on another machine, you already have a personal MPD setup, or you wish to enable access from other clients (e.g. MPDroid). If you select this option then Cantata itself cannot control the starting and stopping of the MPD server. You will therefore need to ensure that MPD is already configured and running.&lt;/i&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/cantata_hu.ts
+++ b/translations/cantata_hu.ts
@@ -11577,7 +11577,7 @@ width x height</comment>
     </message>
     <message>
         <location filename="../mpd-interface/song.cpp" line="565"/>
-        <source>Orignal Year</source>
+        <source>Original Year</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/cantata_hu.ts
+++ b/translations/cantata_hu.ts
@@ -1976,7 +1976,7 @@ i18n: ectx: property (text), widget (QPushButton, connectButton)
     <message>
         <source>A Podcast is currently being downloaded
 
-Quiting now will abort the download.</source>
+Quitting now will abort the download.</source>
         <translation type="vanished">Egy podcast letöltése folyamatban van.
 
 A kilépés megszakítja az adatfolyam letöltését.</translation>
@@ -9111,7 +9111,7 @@ Ha a kereső új dalszöveget talál, hozzákapcsolható az eredeti dalhoz és e
         <location filename="../gui/mainwindow.cpp" line="1128"/>
         <source>A Podcast is currently being downloaded
 
-Quiting now will abort the download.</source>
+Quitting now will abort the download.</source>
         <translation type="unfinished">Egy podcast letöltése folyamatban van.
 
 A kilépés megszakítja az adatfolyam letöltését.</translation>

--- a/translations/cantata_it.ts
+++ b/translations/cantata_it.ts
@@ -2029,7 +2029,7 @@ Non sarà possibile tornare indietro.</translation>
     </message>
     <message>
         <location filename="../gui/initialsettingswizard.ui" line="172"/>
-        <source>&lt;i&gt;Select this option if your music collection is shared between users, your MPD instance is running on another machine, you already have a personal MPD setup, or you wish to enable access from other clients (e.g. MPDroid). If you select this option then Cantata itself cannot control the starting and stopping of the MPD server. You will therfore need to ensure that MPD is already configured and running.&lt;/i&gt;</source>
+        <source>&lt;i&gt;Select this option if your music collection is shared between users, your MPD instance is running on another machine, you already have a personal MPD setup, or you wish to enable access from other clients (e.g. MPDroid). If you select this option then Cantata itself cannot control the starting and stopping of the MPD server. You will therefore need to ensure that MPD is already configured and running.&lt;/i&gt;</source>
         <translation>&lt;i&gt;Scegli quest&apos;opzione se la tua collezione musica è condivisa tra più utenti, se l&apos;istanza MPD viene eseguita su un&apos;altra macchina, se hai già un&apos;impostazione personale di MPD, oppure se vuoi abilitare l&apos;acceso da altri client (es. MPDroid). Se selezionerai questa opzione, Cantata non potrà controllare l&apos;avvio e lo spegnimento del server MPD. Dovrai quindi assicurarti che MPD sia già configurato ed in esecuzione.&lt;/i&gt;</translation>
     </message>
     <message>

--- a/translations/cantata_it.ts
+++ b/translations/cantata_it.ts
@@ -3409,7 +3409,7 @@ Se questa ricerca dovesse trovare nuovi testi, sarebbero ancora associarti al ti
         <location filename="../gui/mainwindow.cpp" line="1128"/>
         <source>A Podcast is currently being downloaded
 
-Quiting now will abort the download.</source>
+Quitting now will abort the download.</source>
         <translation>È in corso lo scaricamento di un podcast
 
 Uscire ora interromperà lo scaricamento.</translation>

--- a/translations/cantata_it.ts
+++ b/translations/cantata_it.ts
@@ -5741,7 +5741,7 @@ width x height</comment>
     </message>
     <message>
         <location filename="../mpd-interface/song.cpp" line="565"/>
-        <source>Orignal Year</source>
+        <source>Original Year</source>
         <translation>Anno Originale</translation>
     </message>
     <message>

--- a/translations/cantata_ja.ts
+++ b/translations/cantata_ja.ts
@@ -4273,7 +4273,7 @@ i18n: ectx: property (text), widget (QRadioButton, advanced)
         <translation type="vanished">標準マルチユーザ/サーバー セットアップ</translation>
     </message>
     <message>
-        <source>&lt;i&gt;Select this option if your music collection is shared between users, your MPD instance is running on another machine, you already have a personal MPD setup, or you wish to enable access from other clients (e.g. MPDroid). If you select this option then Cantata itself cannot control the starting and stopping of the MPD server. You will therfore need to ensure that MPD is already configured and running.&lt;/i&gt;</source>
+        <source>&lt;i&gt;Select this option if your music collection is shared between users, your MPD instance is running on another machine, you already have a personal MPD setup, or you wish to enable access from other clients (e.g. MPDroid). If you select this option then Cantata itself cannot control the starting and stopping of the MPD server. You will therefore need to ensure that MPD is already configured and running.&lt;/i&gt;</source>
         <extracomment>i18n: file: gui/initialsettingswizard.ui:172
 i18n: ectx: property (text), widget (BuddyLabel, label_10)
 </extracomment>
@@ -8169,7 +8169,7 @@ This cannot be undone.</source>
     </message>
     <message>
         <location filename="../gui/initialsettingswizard.ui" line="172"/>
-        <source>&lt;i&gt;Select this option if your music collection is shared between users, your MPD instance is running on another machine, you already have a personal MPD setup, or you wish to enable access from other clients (e.g. MPDroid). If you select this option then Cantata itself cannot control the starting and stopping of the MPD server. You will therfore need to ensure that MPD is already configured and running.&lt;/i&gt;</source>
+        <source>&lt;i&gt;Select this option if your music collection is shared between users, your MPD instance is running on another machine, you already have a personal MPD setup, or you wish to enable access from other clients (e.g. MPDroid). If you select this option then Cantata itself cannot control the starting and stopping of the MPD server. You will therefore need to ensure that MPD is already configured and running.&lt;/i&gt;</source>
         <translation type="unfinished">&lt;i&gt;音楽コレクションがユーザー間で共有されている場合、MPDインスタンスが別のマシンで実行中の場合、個人MPD設定が既にある場合、または他のクライアント（MPDroidなど）からのアクセスを有効にする場合はこのオプションを選択します。このオプションを選択すると、Cantata自体がMPDサーバーの起動と停止を制御できなくなります。MPDが既に設定され、実行されていることを確認する必要があります。&lt;/i&gt;</translation>
     </message>
     <message>

--- a/translations/cantata_ja.ts
+++ b/translations/cantata_ja.ts
@@ -11998,7 +11998,7 @@ width x height</comment>
     </message>
     <message>
         <location filename="../mpd-interface/song.cpp" line="565"/>
-        <source>Orignal Year</source>
+        <source>Original Year</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/cantata_ja.ts
+++ b/translations/cantata_ja.ts
@@ -2040,7 +2040,7 @@ i18n: ectx: property (text), widget (QPushButton, connectButton)
     <message>
         <source>A Podcast is currently being downloaded
 
-Quiting now will abort the download.</source>
+Quitting now will abort the download.</source>
         <translation type="vanished">Podcastは現在ダウンロード中です
 
 終了すると、ダウンロードが中止されます。</translation>
@@ -9559,7 +9559,7 @@ If this search does find new lyrics, these will still be associated with the ori
         <location filename="../gui/mainwindow.cpp" line="1128"/>
         <source>A Podcast is currently being downloaded
 
-Quiting now will abort the download.</source>
+Quitting now will abort the download.</source>
         <translation type="unfinished">Podcastは現在ダウンロード中です
 
 終了すると、ダウンロードが中止されます。</translation>

--- a/translations/cantata_ko.ts
+++ b/translations/cantata_ko.ts
@@ -2102,7 +2102,7 @@ i18n: ectx: property (text), widget (QPushButton, connectButton)
     <message>
         <source>A Podcast is currently being downloaded
 
-Quiting now will abort the download.</source>
+Quitting now will abort the download.</source>
         <translation type="vanished">팟캐스트를 내려받고 있습니다
 
 지금 취소하면 내려받기를 그만둡니다.</translation>
@@ -9685,7 +9685,7 @@ If this search does find new lyrics, these will still be associated with the ori
         <location filename="../gui/mainwindow.cpp" line="1128"/>
         <source>A Podcast is currently being downloaded
 
-Quiting now will abort the download.</source>
+Quitting now will abort the download.</source>
         <translation type="unfinished">팟캐스트를 내려받고 있습니다
 
 지금 취소하면 내려받기를 그만둡니다.</translation>

--- a/translations/cantata_ko.ts
+++ b/translations/cantata_ko.ts
@@ -4381,7 +4381,7 @@ i18n: ectx: property (text), widget (QRadioButton, advanced)
         <translation type="vanished">표준 다수 사용자/서버 설정</translation>
     </message>
     <message>
-        <source>&lt;i&gt;Select this option if your music collection is shared between users, your MPD instance is running on another machine, you already have a personal MPD setup, or you wish to enable access from other clients (e.g. MPDroid). If you select this option then Cantata itself cannot control the starting and stopping of the MPD server. You will therfore need to ensure that MPD is already configured and running.&lt;/i&gt;</source>
+        <source>&lt;i&gt;Select this option if your music collection is shared between users, your MPD instance is running on another machine, you already have a personal MPD setup, or you wish to enable access from other clients (e.g. MPDroid). If you select this option then Cantata itself cannot control the starting and stopping of the MPD server. You will therefore need to ensure that MPD is already configured and running.&lt;/i&gt;</source>
         <extracomment>i18n: file: gui/initialsettingswizard.ui:172
 i18n: ectx: property (text), widget (BuddyLabel, label_10)
 </extracomment>
@@ -8293,7 +8293,7 @@ This cannot be undone.</source>
     </message>
     <message>
         <location filename="../gui/initialsettingswizard.ui" line="172"/>
-        <source>&lt;i&gt;Select this option if your music collection is shared between users, your MPD instance is running on another machine, you already have a personal MPD setup, or you wish to enable access from other clients (e.g. MPDroid). If you select this option then Cantata itself cannot control the starting and stopping of the MPD server. You will therfore need to ensure that MPD is already configured and running.&lt;/i&gt;</source>
+        <source>&lt;i&gt;Select this option if your music collection is shared between users, your MPD instance is running on another machine, you already have a personal MPD setup, or you wish to enable access from other clients (e.g. MPDroid). If you select this option then Cantata itself cannot control the starting and stopping of the MPD server. You will therefore need to ensure that MPD is already configured and running.&lt;/i&gt;</source>
         <translation type="unfinished">&lt;i&gt;음원을 다른 사용자와 공유하고, MPD가 다른 기기에서 실행되거나, 개인설정을 하고, 다른 클라이언트 (예.MPDroid)에서 접속하려면, 이것을 선택합니다. MPD가 이미 설정이 되고 가동 중인 것을 확인해야 합니다.&lt;/i&gt;</translation>
     </message>
     <message>

--- a/translations/cantata_ko.ts
+++ b/translations/cantata_ko.ts
@@ -12182,7 +12182,7 @@ width x height</comment>
     </message>
     <message>
         <location filename="../mpd-interface/song.cpp" line="565"/>
-        <source>Orignal Year</source>
+        <source>Original Year</source>
         <translation type="unfinished">원본 연도</translation>
     </message>
     <message>

--- a/translations/cantata_pl.ts
+++ b/translations/cantata_pl.ts
@@ -2119,7 +2119,7 @@ i18n: ectx: property (text), widget (QPushButton, connectButton)
     <message>
         <source>A Podcast is currently being downloaded
 
-Quiting now will abort the download.</source>
+Quitting now will abort the download.</source>
         <translation type="vanished">Obecnie trwa pobieranie podcastu
 
 Wyjście z programu spowoduje przerwanie pobierania.</translation>
@@ -9745,7 +9745,7 @@ Jeśli to wyszukiwanie się powiedzie, to znaleziony tekst zostanie przyporządk
         <location filename="../gui/mainwindow.cpp" line="1128"/>
         <source>A Podcast is currently being downloaded
 
-Quiting now will abort the download.</source>
+Quitting now will abort the download.</source>
         <translation>Obecnie trwa pobieranie podcastu
 
 Wyjście z programu spowoduje przerwanie pobierania.</translation>

--- a/translations/cantata_pl.ts
+++ b/translations/cantata_pl.ts
@@ -12239,7 +12239,7 @@ width x height</comment>
     </message>
     <message>
         <location filename="../mpd-interface/song.cpp" line="565"/>
-        <source>Orignal Year</source>
+        <source>Original Year</source>
         <translation>Rok oryginału</translation>
     </message>
     <message>

--- a/translations/cantata_pl.ts
+++ b/translations/cantata_pl.ts
@@ -4418,7 +4418,7 @@ i18n: ectx: property (text), widget (QRadioButton, advanced)
         <translation type="vanished">Standardowa wielo-użytkownikowa/serwerowa konfiguracja</translation>
     </message>
     <message>
-        <source>&lt;i&gt;Select this option if your music collection is shared between users, your MPD instance is running on another machine, you already have a personal MPD setup, or you wish to enable access from other clients (e.g. MPDroid). If you select this option then Cantata itself cannot control the starting and stopping of the MPD server. You will therfore need to ensure that MPD is already configured and running.&lt;/i&gt;</source>
+        <source>&lt;i&gt;Select this option if your music collection is shared between users, your MPD instance is running on another machine, you already have a personal MPD setup, or you wish to enable access from other clients (e.g. MPDroid). If you select this option then Cantata itself cannot control the starting and stopping of the MPD server. You will therefore need to ensure that MPD is already configured and running.&lt;/i&gt;</source>
         <extracomment>i18n: file: gui/initialsettingswizard.ui:172
 i18n: ectx: property (text), widget (BuddyLabel, label_10)
 </extracomment>
@@ -8351,7 +8351,7 @@ Ta operacja nie może być cofnięta.</translation>
     </message>
     <message>
         <location filename="../gui/initialsettingswizard.ui" line="172"/>
-        <source>&lt;i&gt;Select this option if your music collection is shared between users, your MPD instance is running on another machine, you already have a personal MPD setup, or you wish to enable access from other clients (e.g. MPDroid). If you select this option then Cantata itself cannot control the starting and stopping of the MPD server. You will therfore need to ensure that MPD is already configured and running.&lt;/i&gt;</source>
+        <source>&lt;i&gt;Select this option if your music collection is shared between users, your MPD instance is running on another machine, you already have a personal MPD setup, or you wish to enable access from other clients (e.g. MPDroid). If you select this option then Cantata itself cannot control the starting and stopping of the MPD server. You will therefore need to ensure that MPD is already configured and running.&lt;/i&gt;</source>
         <translation>&lt;i&gt;Proszę wybrać tę opcję, jeśli kolekcja muzyki jest współdzielona, znajduje się na innej maszynie, jest już skonfigurowa albo ma być używana z innymi klientami (np. MPDroid). Wybranie tej opcji spowoduje, że program Cantata nie będzie mógł kontrolować uruchamiania i wyłączania serwera MPD. Dlatego należy się upewnić, że MPD jest już skonfigurowany i uruchomiony.&lt;/i&gt;</translation>
     </message>
     <message>

--- a/translations/cantata_ru.ts
+++ b/translations/cantata_ru.ts
@@ -7743,7 +7743,7 @@ This cannot be undone.</source>
     </message>
     <message>
         <location filename="../gui/initialsettingswizard.ui" line="172"/>
-        <source>&lt;i&gt;Select this option if your music collection is shared between users, your MPD instance is running on another machine, you already have a personal MPD setup, or you wish to enable access from other clients (e.g. MPDroid). If you select this option then Cantata itself cannot control the starting and stopping of the MPD server. You will therfore need to ensure that MPD is already configured and running.&lt;/i&gt;</source>
+        <source>&lt;i&gt;Select this option if your music collection is shared between users, your MPD instance is running on another machine, you already have a personal MPD setup, or you wish to enable access from other clients (e.g. MPDroid). If you select this option then Cantata itself cannot control the starting and stopping of the MPD server. You will therefore need to ensure that MPD is already configured and running.&lt;/i&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/cantata_ru.ts
+++ b/translations/cantata_ru.ts
@@ -1976,7 +1976,7 @@ i18n: ectx: property (text), widget (QPushButton, connectButton)
     <message>
         <source>A Podcast is currently being downloaded
 
-Quiting now will abort the download.</source>
+Quitting now will abort the download.</source>
         <translation type="vanished">В настоящее время идёт загрузка подкаста.
 
 Выключение прекратит загрузку.</translation>
@@ -9135,7 +9135,7 @@ If this search does find new lyrics, these will still be associated with the ori
         <location filename="../gui/mainwindow.cpp" line="1128"/>
         <source>A Podcast is currently being downloaded
 
-Quiting now will abort the download.</source>
+Quitting now will abort the download.</source>
         <translation type="unfinished">В настоящее время идёт загрузка подкаста.
 
 Выключение прекратит загрузку.</translation>

--- a/translations/cantata_ru.ts
+++ b/translations/cantata_ru.ts
@@ -11613,7 +11613,7 @@ width x height</comment>
     </message>
     <message>
         <location filename="../mpd-interface/song.cpp" line="565"/>
-        <source>Orignal Year</source>
+        <source>Original Year</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/cantata_zh_CN.ts
+++ b/translations/cantata_zh_CN.ts
@@ -8204,7 +8204,7 @@ width x height</comment>
     </message>
     <message>
         <location filename="../mpd-interface/song.cpp" line="565"/>
-        <source>Orignal Year</source>
+        <source>Original Year</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/cantata_zh_CN.ts
+++ b/translations/cantata_zh_CN.ts
@@ -5803,7 +5803,7 @@ If this search does find new lyrics, these will still be associated with the ori
         <location filename="../gui/mainwindow.cpp" line="1128"/>
         <source>A Podcast is currently being downloaded
 
-Quiting now will abort the download.</source>
+Quitting now will abort the download.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/cantata_zh_CN.ts
+++ b/translations/cantata_zh_CN.ts
@@ -4441,7 +4441,7 @@ This cannot be undone.</source>
     </message>
     <message>
         <location filename="../gui/initialsettingswizard.ui" line="172"/>
-        <source>&lt;i&gt;Select this option if your music collection is shared between users, your MPD instance is running on another machine, you already have a personal MPD setup, or you wish to enable access from other clients (e.g. MPDroid). If you select this option then Cantata itself cannot control the starting and stopping of the MPD server. You will therfore need to ensure that MPD is already configured and running.&lt;/i&gt;</source>
+        <source>&lt;i&gt;Select this option if your music collection is shared between users, your MPD instance is running on another machine, you already have a personal MPD setup, or you wish to enable access from other clients (e.g. MPDroid). If you select this option then Cantata itself cannot control the starting and stopping of the MPD server. You will therefore need to ensure that MPD is already configured and running.&lt;/i&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>


### PR DESCRIPTION
Debian's `lintian` QA tool has highlighted the following spelling errors in cantata. `lintian` uses a list of common misspellings rather than a spellchecker.

This sequence of patches changes both the source and also the translation files. I assume that will prevent fuzzing of the translations and that this is the best approach (i.e. translators won't be prompted to confirm that the translations are still correct due to the source text being changed); please let me know if you'd rather only change the .cpp files. 

- therfore → therefore
- quiting → quitting
- orignal → original

Additionally, `lintian` flagged:

-  "Entrys → Entries" as a potential misspelling but I am unable to see it in the source
- "priorty → priority", however this seems not to be user-visible (only in variable names); this is probably also worth fixing to save typo confusion when working on the source and I'll give you another PR for that if you'd like.
