### PR TITLE
Improve drop indicator in table playqueue

### DIFF
--- a/widgets/playqueueview.cpp
+++ b/widgets/playqueueview.cpp
@@ -182,6 +182,7 @@ void PlayQueueView::setMode(ItemView::Mode m)
     case ItemView::Mode_Table:
         if (!treeView) {
             treeView=new PlayQueueTreeView(this);
+            treeView->setStyle(new PlayQueueTreeStyle());
             treeView->setContextMenuPolicy(Qt::ActionsContextMenu);
             treeView->installFilter(new KeyEventHandler(treeView, removeFromAction));
             treeView->initHeader();

--- a/widgets/playqueueview.h
+++ b/widgets/playqueueview.h
@@ -30,6 +30,8 @@
 #include <QPixmap>
 #include <QImage>
 #include <QPropertyAnimation>
+#include <QProxyStyle>
+#include <QPainter>
 #include "tableview.h"
 #include "listview.h"
 #include "groupedview.h"
@@ -44,6 +46,29 @@ class QModelIndex;
 class Spinner;
 class PlayQueueView;
 class MessageOverlay;
+
+class PlayQueueTreeStyle : public QProxyStyle
+{
+public:
+    void drawPrimitive(PrimitiveElement element, const QStyleOption *option, QPainter *painter, const QWidget *widget) const
+    {
+        if (element == QStyle::PE_IndicatorItemViewItemDrop && widget)
+        {
+            painter->setPen(QPen(QPalette::Highlight)); // make the drop indicator more visible
+            painter->setRenderHint(QPainter::Antialiasing, true);
+
+            QStyleOption opt(*option);
+            opt.rect.setLeft(0);                // let the drop indicator
+            opt.rect.setRight(widget->width()); // span a whole tree widget row
+
+            QProxyStyle::drawPrimitive(element, &opt, painter, widget);
+        }
+        else
+        {
+            QProxyStyle::drawPrimitive(element, option, painter, widget);
+        }
+    }
+};
 
 class PlayQueueTreeView : public TableView
 {


### PR DESCRIPTION
In the table play queue the drop indicator is almost not visible when
tracks get moved by drag'n drop. In addition the drop indicator is
only shown in only one column and does not span the whole row. This
change does fix both issues.