### PR TITLE
Fix for playlist number of tracks reverting to 10

### DIFF
--- a/playlists/rulesplaylists.h
+++ b/playlists/rulesplaylists.h
@@ -67,7 +67,7 @@ public:
         int minDuration = 0;
         int maxDuration = 0;
         int maxAge = 0;
-        int numTracks = 10;
+        int numTracks = 0;
         Order order = Order_Random;
         bool orderAscending = true;
     };


### PR DESCRIPTION
The `10` value for `numTracks` is causing the number of tracks in playlists to ignore playlist rules files and revert to 10 whenever Cantata starts. Setting it to `0` seems to fix the problem. 

I couldn't find anything that value change breaks, but I've never written a line of C++ in my life. YMMV.

Cantata is awesome by the way, and the fact an old hacker like me can dig through a language I've never used to fix this problem is a testament to clean, readable code. Kudos. 