### PR TITLE
mpd-interface: basic(str) now strips producer names too

### DIFF
--- a/mpd-interface/song.cpp
+++ b/mpd-interface/song.cpp
@@ -755,7 +755,8 @@ QString Song::albumKey() const
 
 static QString basic(const QString &str)
 {
-    QStringList toStrip=QStringList() << QLatin1String("ft. ") << QLatin1String("feat. ") << QLatin1String("featuring ") << QLatin1String("f. ");
+    QStringList toStrip=QStringList() << QLatin1String("ft. ") << QLatin1String("feat. ") << QLatin1String("featuring ") << QLatin1String("f. ")
+                                      << QLatin1String("prod. ") << QLatin1String("prod ") << QLatin1String("producer ") << QLatin1String("produced ") ;
     QStringList prefixes=QStringList() << QLatin1String(" ") << QLatin1String(" (") << QLatin1String(" [");
 
     for (const QString &s: toStrip) {


### PR DESCRIPTION
I think this addition would be useful.

Reasons why this code is "less than ideal" I could think of:
- basic() is applied both to artist and title fields, while producer names are never(?) encountered in artist fields
- I have encountered only the "prod. " pattern in my music library. I made the other up just to cover all cases but they may be exceedingly rare (Although that most likely doesn't matter because the extra computational cost is insignificant)
