### PR TITLE
Add missing ifdef for libvlc support

### DIFF
--- a/mpd-interface/httpstream.cpp
+++ b/mpd-interface/httpstream.cpp
@@ -192,11 +192,14 @@ void HttpStream::updateStatus()
     DBUG << status->state() << state;
 
     // evaluates to true when it is needed to start or restart media player
-    bool playerNeedsToStart = status->state() == MPDState_Playing &&
+    bool playerNeedsToStart = status->state() == MPDState_Playing;
+    #ifndef LIBVLC_FOUND
+    playerNeedsToStart = playerNeedsToStart &&
            (QMediaPlayer::PlayingState!=player->state() ||
             QMediaPlayer::InvalidMedia == player->mediaStatus() ||
             QMediaPlayer::EndOfMedia == player->mediaStatus() ||
             QMediaPlayer::NoMedia == player->mediaStatus());
+    #endif
 
     if (status->state()==state && !playerNeedsToStart) {
         return;


### PR DESCRIPTION
QMediaPlayer related code was not ifdef'ed out when libvlc is used resulting in compilation errors.

Probably similar checks have to be done when using libvlc as well, but I have only gotten it to compile as it is.
Introduced by @theirix's commit 4699dee13.