### PR TITLE
Wait QMediaPlayer buffering before entering playing state

### DIFF
--- a/mpd-interface/httpstream.h
+++ b/mpd-interface/httpstream.h
@@ -62,6 +62,7 @@ private Q_SLOTS:
     void updateStatus();
     void streamUrl(const QString &url);
     void checkPlayer();
+    void bufferingProgress(int progress);
 
 private:
     void startTimer();


### PR DESCRIPTION
QMediaPlayer needs to fill its internal buffer before it can play the
stream otherwise it can end up in a stalled state.

This commit also simplifies the logic for when the player needs to be
restarted and remove the need of an internal timer to poll the player
state.

Fixes choppy http playback.

Tested on Linux using an mpd server streaming an opus stream at 510~ kbp/s (through nginx via https).

