### PR TITLE
Cleanup scrobbler.cpp

### DIFF
--- a/scrobbling/scrobbler.cpp
+++ b/scrobbling/scrobbler.cpp
@@ -368,10 +368,7 @@ void Scrobbler::setLoveEnabled(bool e)
 
 void Scrobbler::calcScrobbleIntervals()
 {
-    int elapsed=MPDStatus::self()->timeElapsed()*1000;
-    if (elapsed<0) {
-        elapsed=0;
-    }
+    quint16 elapsed=MPDStatus::self()->timeElapsed()*1000;
     int nowPlayingTimemout=constNowPlayingInterval;
     if (elapsed>4000) {
         nowPlayingTimemout=10;


### PR DESCRIPTION
timeElapsed() returns quint16 so it cannot be negative
Changed `int` to `quint16` in order to avoid conversion