### PR TITLE
Fix solid-lite static linking

### DIFF
--- a/3rdparty/solid-lite/CMakeLists.txt
+++ b/3rdparty/solid-lite/CMakeLists.txt
@@ -202,7 +202,7 @@ if(APPLE)
    set(solidlite_OPTIONAL_LIBS ${IOKIT_LIBRARY})
 endif()
 
-add_library(solidlite ${solidlite_LIB_SRCS})
+add_library(solidlite STATIC ${solidlite_LIB_SRCS})
 
 if ( UDEV_FOUND )
    set(solidlite_OPTIONAL_LIBS ${solidlite_OPTIONAL_LIBS} ${UDEV_LIBS})


### PR DESCRIPTION
If `BUILD_SHARED_LIBS` is part of standard system cmake args:
```
  cantata: error while loading shared libraries: libsolidlite.so:
  cannot open shared object file: No such file or directory
```


While I'm at it: Since solid was split out of kdelibs4 as a separate part of KDE Frameworks, is there any appetite to unbundle this lib again?