### PR TITLE
Disable zeroconf for local MPD instances

### DIFF
--- a/mpd-interface/mpd.conf.template
+++ b/mpd-interface/mpd.conf.template
@@ -6,6 +6,7 @@ db_file "${CACHE_DIR}/tag_cache"
 pid_file "${CACHE_DIR}/pid"
 state_file "${CACHE_DIR}/state"
 log_file "/dev/null"
+zeroconf_enabled "no"
 metadata_to_use	"artist,album,title,track,name,genre,date,disc,albumartist,composer,musicbrainz_albumid"
 audio_output { 
   type "pulse"


### PR DESCRIPTION
Instances of MPD started by Cantata do not need to register with Avahi, but zeroconf_enabled defaults to "yes" (https://github.com/MusicPlayerDaemon/MPD/blob/ce49d99c2f3265f2975b2cff583684bf191bbd93/src/zeroconf/ZeroconfGlue.cxx#L47)