### PR TITLE
Prevent Cantata from potentially crashing when closing

### DIFF
--- a/3rdparty/solid-lite/devicemanager.cpp
+++ b/3rdparty/solid-lite/devicemanager.cpp
@@ -59,9 +59,9 @@ Solid::DeviceManagerPrivate::~DeviceManagerPrivate()
         disconnect(backend, nullptr, this, nullptr);
     }
 
-    for (QtPointer<DevicePrivate> dev: m_devicesMap) {
+    for (QtPointer<DevicePrivate> &dev: m_devicesMap) {
         if (dev.data() && !dev.data()->ref.deref()) {
-            delete dev.data();
+            dev.data()->deleteLater();
         }
     }
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -5,6 +5,8 @@
 3. Correctly set 'storeLyricsInMpdDir' config item, UI was setting wrong config
    item.
 4. Set minimum Qt5 version to 5.11
+5. Fix destructor of DeviceManagerPrivate to prevent Cantata from potentially
+   crashing when closing.
 
 2.4.1
 -----


### PR DESCRIPTION
Directly deleting `DevicePrivate` members from within the destructor of `DeviceManagerPrivate` can lead to a crash in Qt's internal memory management. Better defer destruction by using `deleteLater()` like it has already been done in [DevicePrivate::setBackendObject()](https://github.com/CDrummond/cantata/blob/efa907c8e03d052718f14834eb968da86d1c34d8/3rdparty/solid-lite/device.cpp#L312).