### PR TITLE
Fix setting song details in OnlineService::decode()

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -5,6 +5,8 @@
 3. Correctly set 'storeLyricsInMpdDir' config item, UI was setting wrong config
    item.
 4. Set minimum Qt5 version to 5.11
+6. Correctly set song details 'time', 'year', 'track' and 'disc' for streams
+   from online services.
 
 2.4.1
 -----

--- a/online/onlineservice.cpp
+++ b/online/onlineservice.cpp
@@ -81,10 +81,10 @@ bool OnlineService::decode(Song &song)
             song.album=obj["album"].toString();
             song.title=obj["title"].toString();
             song.genres[0]=obj["genre"].toString();
-            if (obj.contains("time")) song.track=obj["time"].toInt();
-            if (obj.contains("year")) song.track=obj["year"].toInt();
+            if (obj.contains("time")) song.time=obj["time"].toInt();
+            if (obj.contains("year")) song.year=obj["year"].toInt();
             if (obj.contains("track")) song.track=obj["track"].toInt();
-            if (obj.contains("disc")) song.track=obj["disc"].toInt();
+            if (obj.contains("disc")) song.disc=obj["disc"].toInt();
             song.setIsFromOnlineService(obj["service"].toString());
             if (obj.contains("imgcache")) song.setExtraField(Song::OnlineImageCacheName, obj["imgcache"].toString());
             if (obj.contains("imgurl")) song.setExtraField(Song::OnlineImageUrl, obj["imgurl"].toString());


### PR DESCRIPTION
This seems to be a copy-paste error. Before the fix, 'time', 'year' and 'disc' have also been mapped to `song.track`. So it happened that the information about the duration of podcasts was missing for instance (and track number was set to garbage instead).