### PR TITLE
Avoid passing empty string as file name to QFile::exists()

### DIFF
--- a/online/podcastservice.cpp
+++ b/online/podcastservice.cpp
@@ -293,7 +293,7 @@ bool PodcastService::Podcast::load()
                     ep->duration=time.isEmpty() ? 0 : time.toUInt();
                     ep->played=constTrue==attributes.value(constPlayedAttribute).toString();
                     ep->descr=attributes.value(constDescrAttribute).toString();
-                    if (QFile::exists(localFile)) {
+                    if (!localFile.isEmpty() && QFile::exists(localFile)) {
                         ep->localFile=localFile;
                     } else if (!podPath.isEmpty()) {
                         QString localPath=podPath+episodeFileName(ep->url);


### PR DESCRIPTION
Check whether the string object `localFile` is nonempty to get rid of _"Empty filename passed to function"_ console messages while loading podcasts. I know that this issue has been fixed in Qt 5.12, but if you have an older Qt release, this message is flooding the console. It's just annoying.