### PR TITLE
Fix default cover icons

### DIFF
--- a/gui/currentcover.cpp
+++ b/gui/currentcover.cpp
@@ -75,9 +75,9 @@ QString CurrentCover::findIcon(const QStringList &names)
     QList<int> sizes=QList<int>() << 256 << 128 << 64 << 48 << 32 << 24 << 22;
     QStringList paths=QIcon::themeSearchPaths();
     QStringList sections=QStringList() << "categories" << "devices";
-    for (const QString &p: paths) {;
+    for (const QString &theme: iconThemes) {
         for (const QString &n: names) {
-            for (const QString &theme: iconThemes) {
+            for (const QString &p: paths) {
                 QMap<int, QString> files;
                 for (int s: sizes) {
                     for (const QString &sect: sections) {

--- a/gui/currentcover.h
+++ b/gui/currentcover.h
@@ -56,7 +56,7 @@ private Q_SLOTS:
     void setDefault();
 
 private:
-    const QImage & stdImage(bool stream);
+    const QImage & stdImage(const Song &s);
     #if !defined Q_OS_WIN && !defined Q_OS_MAC
     void initIconThemes();
     QString findIcon(const QStringList &names);
@@ -69,8 +69,10 @@ private:
     mutable QImage img;
     QString coverFileName;
     QImage noStreamCover;
+    QImage noPodcastCover;
     QImage noCover;
     QString noStreamCoverFileName;
+    QString noPodcastCoverFileName;
     QString noCoverFileName;
     QTimer *timer;
     #if !defined Q_OS_WIN && !defined Q_OS_MAC

--- a/widgets/coverwidget.cpp
+++ b/widgets/coverwidget.cpp
@@ -67,7 +67,7 @@ void CoverLabel::updateToolTip(bool isEvent)
     }
 
     const Song &current=CurrentCover::self()->song();
-    if (current.isEmpty() || (current.isStream() && !current.isCantataStream() && !current.isCdda()) || OnlineService::showLogoAsCover(current)) {
+    if (current.isEmpty() || current.isStandardStream() || OnlineService::showLogoAsCover(current)) {
         setToolTip(QString());
         return;
     }


### PR DESCRIPTION
The default icons shown as fallback in the play queue and the tray item should be the same as well if no cover has been found. So I changed `CurrentCover::stdImage()` to return `Icons::podcastIcon` if no image could be found as cover for the current podcast as well as I changed `Covers::defaultPix()` to return `Icons::streamIcon` if there is no separate image for something from the internet.
In addition, I changed the search order for icons in `CurrentCover::findIcon()` to stick with the same icon theme as long as possible, i.e., first check all storage locations with the same icon theme for the wanted icon before to switch to the next icon theme.