### PR TITLE
Amend MPRIS interface

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -14,6 +14,7 @@
    styles in interface settings.
 9. When checking if song exists, check disc number.
 10. Fix getting song details from Cantata stream URLs.
+11. MPRIS interface: fix if condition for CanSeek status update.
 
 2.4.1
 -----

--- a/ChangeLog
+++ b/ChangeLog
@@ -15,6 +15,7 @@
 9. When checking if song exists, check disc number.
 10. Fix getting song details from Cantata stream URLs.
 11. MPRIS interface: fix if condition for CanSeek status update.
+12. MPRIS interface: fix CanPlay/CanPause status update.
 
 2.4.1
 -----

--- a/ChangeLog
+++ b/ChangeLog
@@ -14,9 +14,8 @@
    styles in interface settings.
 9. When checking if song exists, check disc number.
 10. Fix getting song details from Cantata stream URLs.
-11. MPRIS interface: fix if condition for CanSeek status update.
-12. MPRIS interface: fix CanPlay/CanPause status update.
-13. MPRIS interface: fix LoopStatus getter and setter.
+11. Amend MPRIS interface: fix CanPlay/CanPause/CanSeek status update as well
+    as LoopStatus getter and setter.
 
 2.4.1
 -----

--- a/ChangeLog
+++ b/ChangeLog
@@ -16,6 +16,7 @@
 10. Fix getting song details from Cantata stream URLs.
 11. MPRIS interface: fix if condition for CanSeek status update.
 12. MPRIS interface: fix CanPlay/CanPause status update.
+13. MPRIS interface: fix LoopStatus getter and setter.
 
 2.4.1
 -----

--- a/dbus/mpris.cpp
+++ b/dbus/mpris.cpp
@@ -117,8 +117,10 @@ void Mpris::updateStatus()
     }
     if (MPDStatus::self()->state()!=status.state) {
         map.insert("PlaybackStatus", PlaybackStatus());
-        //map.insert("CanPlay", CanPlay());
-        //map.insert("CanPause", CanPause());
+        map.insert("CanPause", CanPause());
+    }
+    if (MPDStatus::self()->playlistLength()!=status.playlistLength) {
+        map.insert("CanPlay", CanPlay());
     }
     if (MPDStatus::self()->songId()!=status.songId) {
         map.insert("CanSeek", CanSeek());

--- a/dbus/mpris.cpp
+++ b/dbus/mpris.cpp
@@ -45,6 +45,7 @@ Mpris::Mpris(QObject *p)
     QDBusConnection::sessionBus().registerObject("/org/mpris/MediaPlayer2", this, QDBusConnection::ExportAdaptors);
     connect(this, SIGNAL(setRandom(bool)), MPDConnection::self(), SLOT(setRandom(bool)));
     connect(this, SIGNAL(setRepeat(bool)), MPDConnection::self(), SLOT(setRepeat(bool)));
+    connect(this, SIGNAL(setSingle(bool)), MPDConnection::self(), SLOT(setSingle(bool)));
     connect(this, SIGNAL(setSeekId(qint32, quint32)), MPDConnection::self(), SLOT(setSeekId(qint32, quint32)));
     connect(this, SIGNAL(seek(qint32)), MPDConnection::self(), SLOT(seek(qint32)));
     connect(this, SIGNAL(setVolume(int)), MPDConnection::self(), SLOT(setVolume(int)));
@@ -88,6 +89,19 @@ QString Mpris::PlaybackStatus() const
     case MPDState_Paused: return QLatin1String("Paused");
     default:
     case MPDState_Stopped: return QLatin1String("Stopped");
+    }
+}
+
+void Mpris::SetLoopStatus(const QString &s)
+{
+    bool repeat=(QLatin1String("None")!=s);
+    bool single=(QLatin1String("Track")==s);
+
+    if (MPDStatus::self()->repeat()!=repeat) {
+        emit setRepeat(repeat);
+    }
+    if (MPDStatus::self()->single()!=single) {
+        emit setSingle(single);
     }
 }
 

--- a/dbus/mpris.cpp
+++ b/dbus/mpris.cpp
@@ -119,6 +119,8 @@ void Mpris::updateStatus()
         map.insert("PlaybackStatus", PlaybackStatus());
         //map.insert("CanPlay", CanPlay());
         //map.insert("CanPause", CanPause());
+    }
+    if (MPDStatus::self()->songId()!=status.songId) {
         map.insert("CanSeek", CanSeek());
     }
     if (MPDStatus::self()->timeElapsed()!=status.timeElapsed) {

--- a/dbus/mpris.h
+++ b/dbus/mpris.h
@@ -93,8 +93,8 @@ public:
     double MinimumRate() const { return 1.0; }
     double MaximumRate() const { return 1.0; }
     bool CanControl() const { return true; }
-    bool CanPlay() const { return true; }
-    bool CanPause() const { return true; }
+    bool CanPlay() const { return MPDStatus::self()->playlistLength()>0; }
+    bool CanPause() const { return MPDState_Stopped!=MPDStatus::self()->state(); }
     bool CanSeek() const { return -1!=MPDStatus::self()->songId() && !currentSong.isCdda() && !currentSong.isStandardStream() && currentSong.time>5; }
     bool CanGoNext() const { return MPDState_Stopped!=MPDStatus::self()->state() && MPDStatus::self()->playlistLength()>1; }
     bool CanGoPrevious() const { return MPDState_Stopped!=MPDStatus::self()->state() && MPDStatus::self()->playlistLength()>1; }

--- a/dbus/mpris.h
+++ b/dbus/mpris.h
@@ -80,8 +80,8 @@ public:
     void SetPosition(const QDBusObjectPath &trackId, qlonglong pos);
     void OpenUri(const QString &) { }
     QString PlaybackStatus() const;
-    QString LoopStatus() { return MPDStatus::self()->repeat() ? QLatin1String("Playlist") : QLatin1String("None"); }
-    void SetLoopStatus(const QString &s) { emit setRepeat(QLatin1String("None")!=s); }
+    QString LoopStatus() { return MPDStatus::self()->repeat() ? (MPDStatus::self()->single() ? QLatin1String("Track") : QLatin1String("Playlist")) : QLatin1String("None"); }
+    void SetLoopStatus(const QString &s);
     QVariantMap Metadata() const;
     int Rate() const { return 1.0; }
     void SetRate(double) { }
@@ -119,6 +119,7 @@ Q_SIGNALS:
     // org.mpris.MediaPlayer2.Player
     void setRandom(bool toggle);
     void setRepeat(bool toggle);
+    void setSingle(bool toggle);
     void setSeekId(qint32 songId, quint32 time);
     void seek(qint32 offset);
     void setVolume(int vol);


### PR DESCRIPTION
I have fixed and re-enabled `CanPlay`/`CanPause` as well as I have fixed `CanGoNext` (which is now false if it is already the last item playing) and `CanGoPrevious` (which is now false if it is the first item playing). In addition, both properties `CanGoNext` and `CanGoPrevious` are always updated when the play queue changes or the position of the currently selected item (which includes switching to the next song and similar things).