### PR TITLE
Fix getting song details from Cantata stream URLs

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -13,6 +13,7 @@
 8. Hide BB10 styles (look bad), and gtk2 style (doesn't start) from list of
    styles in interface settings.
 9. When checking if song exists, check disc number.
+10. Fix getting song details from Cantata stream URLs.
 
 2.4.1
 -----

--- a/mpd-interface/mpdparseutils.cpp
+++ b/mpd-interface/mpdparseutils.cpp
@@ -382,12 +382,15 @@ Song MPDParseUtils::parseSong(const QList<QByteArray> &lines, Location location)
         if (!song.file.isEmpty() && song.file.startsWith(constHttpProtocol) && HttpServer::self()->isOurs(song.file)) {
             song.type=Song::CantataStream;
             Song mod=HttpServer::self()->decodeUrl(song.file);
-            mod.priority=song.priority;
             if (!mod.title.isEmpty()) {
                 mod.id=song.id;
+                mod.priority=song.priority;
                 song=mod;
-                song.setLocalPath(mod.file);
+            } else {
+                song.file=mod.file;
+                song.time=mod.time;
             }
+            song.setLocalPath(mod.file);
             modifiedFile=true;
         } else
         #endif


### PR DESCRIPTION
The problem comes up when playing local audio files without tags (esp. missing title information). In this case the information returned from `HttpServer::decodeUrl()` would have been completely ignored, e.g., `Song::time` which is why the duration information is missing in the play queue.