### PR TITLE
Fix enabling of play queue navigation actions 'next' and 'previous'

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -23,6 +23,7 @@
 15. Add chartlyrics.com to list of lyrics providers.
 16. Set default lyrics providers to azlyrics.com, chartlyrics.com, and
     lyrics.wikia.com
+17. Fix enabling of play queue navigation actions 'next' and 'previous'.
 
 2.4.1
 -----

--- a/dbus/mpris.cpp
+++ b/dbus/mpris.cpp
@@ -147,7 +147,7 @@ void Mpris::updateStatus(MPDStatus * const status)
     if (status->volume()!=lastStatus.volume) {
         map.insert("Volume", Volume());
     }
-    if (status->state()!=lastStatus.state || status->playlistLength()!=lastStatus.playlistLength) {
+    if (status->state()!=lastStatus.state || status->songId()!=lastStatus.songId || status->nextSongId()!=lastStatus.nextSongId || status->playlistLength()!=lastStatus.playlistLength) {
         map.insert("CanGoNext", CanGoNext());
         map.insert("CanGoPrevious", CanGoPrevious());
     }

--- a/dbus/mpris.h
+++ b/dbus/mpris.h
@@ -97,8 +97,8 @@ public:
     bool CanPlay() const { return !status.isNull() && status->playlistLength()>0; }
     bool CanPause() const { return !status.isNull() && MPDState_Stopped!=status->state() && status->songId()!=-1; }
     bool CanSeek() const { return !status.isNull() && status->songId()!=-1 && !currentSong.isCdda() && !currentSong.isStandardStream() && currentSong.time>5; }
-    bool CanGoNext() const { return !status.isNull() && MPDState_Stopped!=status->state() && status->playlistLength()>1; }
-    bool CanGoPrevious() const { return !status.isNull() && MPDState_Stopped!=status->state() && status->playlistLength()>1; }
+    bool CanGoNext() const { return !status.isNull() && MPDState_Stopped!=status->state() && status->songId()!=-1 && status->nextSongId()!=-1; }
+    bool CanGoPrevious() const { return !status.isNull() && MPDState_Stopped!=status->state() && status->songId()!=-1 && (status->playlistLength()>1 || currentSong.time>5); }
 
     // org.mpris.MediaPlayer2
     bool CanQuit() const { return true; }

--- a/mpd-interface/mpdconnection.cpp
+++ b/mpd-interface/mpdconnection.cpp
@@ -1264,8 +1264,14 @@ void MPDConnection::getReplayGain()
 void MPDConnection::goToNext()
 {
     toggleStopAfterCurrent(false);
-    stopVolumeFade();
-    sendCommand("next");
+    Response status=sendCommand("status");
+    if (status.ok) {
+        MPDStatusValues sv=MPDParseUtils::parseStatus(status.data);
+        if (MPDState_Stopped!=sv.state && -1!=sv.nextSongId) {
+            stopVolumeFade();
+            sendCommand("next");
+        }
+    }
 }
 
 static inline QByteArray value(bool b)

--- a/windows/thumbnailtoolbar.h
+++ b/windows/thumbnailtoolbar.h
@@ -25,9 +25,11 @@
 #define WINTHUMBNAILTOOLBAR_H
 
 #include <QWinThumbnailToolBar>
+#include <QPointer>
+#include "mpd-interface/song.h"
+#include "mpd-interface/mpdstatus.h"
 
 class QWinThumbnailToolButton;
-class MPDStatus;
 class Action;
 class ThumbnailToolBar : public QWinThumbnailToolBar
 {
@@ -36,12 +38,16 @@ public:
     virtual ~ThumbnailToolBar() { }
 
     void readSettings();
-    void update(MPDStatus * const status);
+    void updateCurrentSong(const Song &song);
+    void updateStatus(MPDStatus * const status);
 
 private:
+    void update();
     QWinThumbnailToolButton * createButton(Action *act);
 
 private:
+    Song currentSong;
+    QPointer<MPDStatus> status;
     QWinThumbnailToolButton *prevButton;
     QWinThumbnailToolButton *playPauseButton;
     QWinThumbnailToolButton *stopButton;


### PR DESCRIPTION
As already partly discussed in #1592, this fixes enabling of the play queue navigation actions 'next' and 'previous'. I've tested it, it's properly working for me since 10 days and I hope I've covered almost all use cases. Craig, what do you think?