### PR TITLE
Fix and amend invocation of sleep inhibition

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -25,6 +25,7 @@
     lyrics.wikia.com
 17. Fix enabling of play queue navigation actions 'next' and 'previous'.
 18. Fix bus name of freedesktop.org's power management.
+19. Additionally call Inhibit() from org.freedesktop.login1.Manager.
 
 2.4.1
 -----

--- a/ChangeLog
+++ b/ChangeLog
@@ -24,6 +24,7 @@
 16. Set default lyrics providers to azlyrics.com, chartlyrics.com, and
     lyrics.wikia.com
 17. Fix enabling of play queue navigation actions 'next' and 'previous'.
+18. Fix bus name of freedesktop.org's power management.
 
 2.4.1
 -----

--- a/dbus/powermanagement.cpp
+++ b/dbus/powermanagement.cpp
@@ -28,6 +28,7 @@
 #include "upowerinterface.h"
 #include "login1interface.h"
 #include "mpd-interface/mpdstatus.h"
+#include <QGuiApplication>
 #include <QString>
 
 GLOBAL_STATIC(PowerManagement, instance)
@@ -77,17 +78,17 @@ void PowerManagement::beginSuppressingSleep()
     QString reason=tr("Cantata is playing a track");
     QDBusReply<uint> reply;
     if (policy->isValid()) {
-        reply = policy->AddInhibition((uint)1, QCoreApplication::applicationName(), reason);
+        reply = policy->AddInhibition((uint)1, QGuiApplication::applicationDisplayName(), reason);
     } else {
         // Fallback to the fd.o Inhibit interface
-        reply = inhibit->Inhibit(QCoreApplication::applicationName(), reason);
+        reply = inhibit->Inhibit(QGuiApplication::applicationDisplayName(), reason);
     }
     cookie=reply.isValid() ? reply : -1;
 
     QString types=QStringLiteral("sleep");
     QString mode=QStringLiteral("block");
     QDBusPendingReply<QDBusUnixFileDescriptor> futureReply;
-    futureReply = login1->Inhibit(types, QCoreApplication::applicationName(), reason, mode);
+    futureReply = login1->Inhibit(types, QGuiApplication::applicationDisplayName(), reason, mode);
     futureReply.waitForFinished();
     if (futureReply.isValid()) {
         descriptor=futureReply.value();

--- a/dbus/powermanagement.cpp
+++ b/dbus/powermanagement.cpp
@@ -38,7 +38,7 @@ PowerManagement::PowerManagement()
     policy = new OrgKdeSolidPowerManagementPolicyAgentInterface(OrgKdeSolidPowerManagementPolicyAgentInterface::staticInterfaceName(),
                                                                 QLatin1String("/org/kde/Solid/PowerManagement/PolicyAgent"),
                                                                 QDBusConnection::sessionBus(), this);
-    inhibit = new OrgFreedesktopPowerManagementInhibitInterface(OrgFreedesktopPowerManagementInhibitInterface::staticInterfaceName(),
+    inhibit = new OrgFreedesktopPowerManagementInhibitInterface("org.freedesktop.PowerManagement",
                                                                 QLatin1String("/org/freedesktop/PowerManagement/Inhibit"),
                                                                 QDBusConnection::sessionBus(), this);
     upower = new OrgFreedesktopUPowerInterface(OrgFreedesktopUPowerInterface::staticInterfaceName(),

--- a/dbus/powermanagement.cpp
+++ b/dbus/powermanagement.cpp
@@ -28,6 +28,7 @@
 #include "upowerinterface.h"
 #include "login1interface.h"
 #include "mpd-interface/mpdstatus.h"
+#include <QString>
 
 GLOBAL_STATIC(PowerManagement, instance)
 
@@ -69,9 +70,10 @@ void PowerManagement::setInhibitSuspend(bool i)
 
 void PowerManagement::beginSuppressingSleep()
 {
-    if (-1!=cookie) {
+    if (-1!=cookie || descriptor.isValid()) {
         return;
     }
+
     QString reason=tr("Cantata is playing a track");
     QDBusReply<uint> reply;
     if (policy->isValid()) {
@@ -81,21 +83,33 @@ void PowerManagement::beginSuppressingSleep()
         reply = inhibit->Inhibit(QCoreApplication::applicationName(), reason);
     }
     cookie=reply.isValid() ? reply : -1;
+
+    QString types=QStringLiteral("sleep");
+    QString mode=QStringLiteral("block");
+    QDBusPendingReply<QDBusUnixFileDescriptor> futureReply;
+    futureReply = login1->Inhibit(types, QCoreApplication::applicationName(), reason, mode);
+    futureReply.waitForFinished();
+    if (futureReply.isValid()) {
+        descriptor=futureReply.value();
+    }
 }
 
 void PowerManagement::stopSuppressingSleep()
 {
-    if (-1==cookie) {
-        return;
+    if (-1!=cookie) {
+        if (policy->isValid()) {
+            policy->ReleaseInhibition(cookie);
+        } else {
+            // Fallback to the fd.o Inhibit interface
+            inhibit->UnInhibit(cookie);
+        }
+        cookie=-1;
     }
 
-    if (policy->isValid()) {
-        policy->ReleaseInhibition(cookie);
-    } else {
-        // Fallback to the fd.o Inhibit interface
-        inhibit->UnInhibit(cookie);
+    if (descriptor.isValid()) {
+        QDBusUnixFileDescriptor invalidDescriptor;
+        descriptor.swap(invalidDescriptor);
     }
-    cookie=-1;
 }
 
 void PowerManagement::mpdStatusUpdated()

--- a/dbus/powermanagement.h
+++ b/dbus/powermanagement.h
@@ -25,7 +25,7 @@
 #define POWERMANAGEMENT_H
 
 #include <QObject>
-#include <QString>
+#include <QDBusUnixFileDescriptor>
 
 class OrgKdeSolidPowerManagementPolicyAgentInterface;
 class OrgFreedesktopPowerManagementInhibitInterface;
@@ -54,6 +54,7 @@ private Q_SLOTS:
 private:
     bool inhibitSuspendWhilstPlaying;
     int cookie;
+    QDBusUnixFileDescriptor descriptor;
     OrgKdeSolidPowerManagementPolicyAgentInterface *policy;
     OrgFreedesktopPowerManagementInhibitInterface *inhibit;
     OrgFreedesktopUPowerInterface *upower;


### PR DESCRIPTION
1. Make the fallback to freedesktop.org's power management working by fixing its bus name.
2. Amend the implementation by
   – additionally calling `Inhibit()` from `org.freedesktop.login1.Manager` to also support desktop environments that do not provide the interface `org.freedesktop.PowerManagement.Inhibit` (which is the case for newer GNOME releases for instance) and by
   – using `QGuiApplication::applicationDisplayName()` instead of `QCoreApplication::applicationName()` for a consistent spelling of the application name (cf. `Notify::show()`).