### PR TITLE
Query Qt whether system tray is available if not (Unity flavored) GNOME

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -26,6 +26,8 @@
 17. Fix enabling of play queue navigation actions 'next' and 'previous'.
 18. Fix bus name of freedesktop.org's power management.
 19. Additionally call Inhibit() from org.freedesktop.login1.Manager.
+20. Query Qt whether system tray is available if current desktop environment is
+    not some kind of GNOME (incl. Unity flavored GNOME).
 
 2.4.1
 -----

--- a/support/utils.cpp
+++ b/support/utils.cpp
@@ -35,6 +35,7 @@
 #include <QDesktopWidget>
 #include <QEventLoop>
 #include <QStandardPaths>
+#include <QSystemTrayIcon>
 #include <QSet>
 #include <QUrl>
 #ifndef _MSC_VER 
@@ -982,9 +983,11 @@ bool Utils::useSystemTray()
     #elif defined Q_OS_WIN
     return true;
     #elif QT_QTDBUS_FOUND
-    return Gnome==currentDe() ? QDBusConnection::sessionBus().interface()->isServiceRegistered("org.kde.StatusNotifierWatcher") : true;
+    return (Gnome==currentDe() || Unity==currentDe())
+            ? QDBusConnection::sessionBus().interface()->isServiceRegistered("org.kde.StatusNotifierWatcher")
+            : QSystemTrayIcon::isSystemTrayAvailable();
     #else
-    return Gnome!=currentDe();
+    return Gnome!=currentDe() && Unity!=currentDe() && QSystemTrayIcon::isSystemTrayAvailable();
     #endif
 }
 


### PR DESCRIPTION
- Since 2017, Unity is yet a special Ubuntu flavor of GNOME. That is why system tray support with `QSystemTrayIcon` is only provided if the Ayatana Indicator application or the GNOME Shell extension AppIndicator or something similar that implements `org.kde.StatusNotifierWatcher` is installed and running. Hence, Unity should be treated the same as plain GNOME.
- Although Qt prefers to internally use `QDBusTrayIcon` for `QSystemTrayIcon` (cf. qt/qtbase@38abd653774aa0b3c5cdfd9a8b78619605230726), there is also a fallback implementation using XCB if Qt has X11 support and `org.kde.StatusNotifierWatcher` is not registered on D-Bus. There are settings with some desktop environments where none of these mechanisms are available. So it is not safe to assume `QSystemTrayIcon` is working if `Utils::currentDe()` returns `Utils::Other`. Perhaps the only way then is to simply rely on `QSystemTrayIcon::isSystemTrayAvailable()` and hope for the best.