### PR TITLE
Fix writing 'descr' attribute when saving podcast information

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -28,6 +28,7 @@
 19. Additionally call Inhibit() from org.freedesktop.login1.Manager.
 20. Query Qt whether system tray is available if current desktop environment is
     not some kind of GNOME (incl. Unity flavored GNOME).
+21. Fix writing 'descr' attribute when saving podcast information to cache dir.
 
 2.4.1
 -----

--- a/online/podcastservice.cpp
+++ b/online/podcastservice.cpp
@@ -332,7 +332,7 @@ bool PodcastService::Podcast::save() const
     writer.writeAttribute(constImageAttribute, imageUrl.toString()); // ??
     writer.writeAttribute(constRssAttribute, url.toString()); // ??
     writer.writeAttribute(constNameAttribute, name);
-    writer.writeAttribute(constDateAttribute, descr);
+    writer.writeAttribute(constDescrAttribute, descr);
     for (Episode *ep: episodes) {
         writer.writeStartElement(constEpisodeTag);
         writer.writeAttribute(constNameAttribute, ep->name);

--- a/online/podcastservice.cpp
+++ b/online/podcastservice.cpp
@@ -551,7 +551,7 @@ static QString trimDescr(QString descr, int limit=1000)
         if (descr.length()>limit) {
             descr=descr.left(limit)+QLatin1String("...");
         }
-        descr+=QLatin1String("<br/><br/>");
+        descr=QLatin1String("<br/>")+descr+QLatin1String("<br/><br/>");
     }
     return descr;
 }


### PR DESCRIPTION
- Fix writing 'descr' attribute in PodcastService::Podcast::save().
-  Insert additional line break between title and description in tooltip to better separate long titles from the descriptions.