### PR TITLE
Fix loading and showing cover images in context view

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -29,6 +29,7 @@
 20. Query Qt whether system tray is available if current desktop environment is
     not some kind of GNOME (incl. Unity flavored GNOME).
 21. Fix writing 'descr' attribute when saving podcast information to cache dir.
+22. Fix loading cover images with wrong file extension in context view.
 
 2.4.1
 -----

--- a/context/view.cpp
+++ b/context/view.cpp
@@ -57,7 +57,7 @@ QString View::encode(const QImage &img)
     buffer.open(QIODevice::WriteOnly);
     img.save(&buffer, "PNG");
     #ifdef CONTEXT_CENTERED
-    return QString("<table width=\"100%\"><tr><td align=\"center\"><img src=\"data:image/png;base64,%1\"/></td></tr></table>").arg(QString(buffer.data().toBase64()));
+    return QString("<div style=\"text-align:center;\"><img src=\"data:image/png;base64,%1\"/></div>").arg(QString(buffer.data().toBase64()));
     #else
     return QString("<img src=\"data:image/png;base64,%1\"/>").arg(QString(buffer.data().toBase64()));
     #endif
@@ -175,7 +175,7 @@ QString View::createPicTag(const QImage &img, const QString &file)
 {
     if (!file.isEmpty() && QFile::exists(file)) {
         #ifdef CONTEXT_CENTERED
-        return QString("<table width=\"100%\"><tr><td align=\"center\"><img src=\"%1\"/></td></tr></table>").arg(file);
+        return QString("<div style=\"text-align:center;\"><img src=\"%1\"/></div>").arg(file);
         #else
         return QString("<img src=\"%1\"/>").arg(file);
         #endif


### PR DESCRIPTION
* Fix loading images with wrong file extension in `TextBrowser::loadResource()`.
* Amend `View::createPicTag()` by using a `<div>` container instead of the `<table>` work-around to center the covers in the context view because the latter sometimes does not seem to work properly.