### PR TITLE
Fix Song::filePath()

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -30,6 +30,8 @@
     not some kind of GNOME (incl. Unity flavored GNOME).
 21. Fix writing 'descr' attribute when saving podcast information to cache dir.
 22. Fix loading cover images with wrong file extension in context view.
+23. Avoid prepending song's file path with MPD's music directory if it is empty,
+    a stream URL or an absolute path.
 
 2.4.1
 -----

--- a/mpd-interface/song.cpp
+++ b/mpd-interface/song.cpp
@@ -816,8 +816,8 @@ QString Song::filePath(const QString &base) const
         return file;
     }
     QString fileName=decodePath(file, isCdda());
-    if (!base.isEmpty()) {
-        bool haveAbsPath=fileName.startsWith("/"); // Utils::constDirSep
+    if (!base.isEmpty() && !fileName.isEmpty() && !isNonMPD()) {
+        bool haveAbsPath=fileName.startsWith("/") || fileName.contains(":/");
         if (!haveAbsPath) {
             return QString(base+fileName);
         }


### PR DESCRIPTION
Avoid prepending song's file path with MPD's music directory if it is empty, a stream URL (by checking `isNonMPD()` or an absolute path (those from UNIX starts with a slash though, but on Windows it's something like `C:/...`).