### PR TITLE
Fix MainWindow::moveSelectionAfterCurrentSong()

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -32,6 +32,8 @@
 22. Fix loading cover images with wrong file extension in context view.
 23. Avoid prepending song's file path with MPD's music directory if it is empty,
     a stream URL or an absolute path.
+24. Ignore current song in selection when moving selected songs within the play
+    queue to play them next.
 
 2.4.1
 -----

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -2322,16 +2322,17 @@ void MainWindow::locateTrack()
 
 void MainWindow::moveSelectionAfterCurrentSong()
 {
-    QList<int> selectedIdexes = playQueueProxyModel.mapToSourceRows(playQueue->selectedIndexes());
+    QList<int> selectedRows = playQueueProxyModel.mapToSourceRows(playQueue->selectedIndexes());
+    int currentSongIdx = PlayQueueModel::self()->currentSongRow();
+    QList<quint32> selectedSongIds;
 
-    if( !selectedIdexes.empty() ){
-        QList<quint32> selectedSongIds;
-        for (int row: selectedIdexes){
+    for (int row: selectedRows) {
+        if (currentSongIdx!=row) {
             selectedSongIds.append( (quint32) row);
         }
+    }
 
-        int currentSongIdx = PlayQueueModel::self()->currentSongRow();
-
+    if( !selectedSongIds.empty() ) {
         emit playNext(selectedSongIds, currentSongIdx+1, PlayQueueModel::self()->rowCount());
     }
 }


### PR DESCRIPTION
MPD reports an error unless we ignore current song in selection when moving selected songs within the play queue to play them next.