### PR TITLE
Change SongView::update() to always update and show metadata

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -34,6 +34,8 @@
     a stream URL or an absolute path.
 24. Ignore current song in selection when moving selected songs within the play
     queue to play them next.
+25. Also show metadata of the current track in the context view if 'title' or
+    'artist' are missing, but do not try to fetch information nor lyrics.
 
 2.4.1
 -----

--- a/context/songview.cpp
+++ b/context/songview.cpp
@@ -747,7 +747,7 @@ void SongView::abort()
 
 void SongView::update(const Song &s, bool force)
 {
-    if (s.isEmpty() || s.title.isEmpty() || s.artist.isEmpty()) {
+    if (s.isEmpty()) {
         currentSong=s;
         infoNeedsUpdating=metadataNeedsUpdating=lyricsNeedsUpdating=false;
         clear();
@@ -772,12 +772,13 @@ void SongView::update(const Song &s, bool force)
     if (force || songChanged) {
         setMode(Mode_Blank);
 //        controls->setVisible(true);
-        currentRequest++;
-        currentSong=song;
 
         if (song.title.isEmpty() || song.artist.isEmpty()) {
             clear();
-            return;
+            infoNeedsUpdating=lyricsNeedsUpdating=false;
+        } else {
+            currentRequest++;
+            infoNeedsUpdating=lyricsNeedsUpdating=true;
         }
 
         // Only reset the provider if the refresh was an automatic one or if the song has
@@ -786,9 +787,15 @@ void SongView::update(const Song &s, bool force)
         if (!force || songChanged) {
             currentProvider=-1;
         }
+    }
 
-        infoNeedsUpdating=metadataNeedsUpdating=lyricsNeedsUpdating=true;
+    metadataNeedsUpdating=force || song.isDifferent(currentSong);
+    currentSong=song;
+
+    if (!song.title.isEmpty()) {
         setHeader(song.title);
+    }
+    if (metadataNeedsUpdating || infoNeedsUpdating || lyricsNeedsUpdating) {
         curentViewChanged();
     }
 }


### PR DESCRIPTION
Also show metadata of the current track in the context view if `'title'` or `'artist'` are missing, but keep not to fetch information nor lyrics. Also update metadata if other tags different from `'title'` or `'artist'` change (by using `Song::isDifferent()` instead of `songChanged`).