### PR TITLE
Update deprecated code to remove compiler warnings

### DIFF
--- a/3rdparty/solid-lite/backends/hal/halfstabhandling.cpp
+++ b/3rdparty/solid-lite/backends/hal/halfstabhandling.cpp
@@ -25,7 +25,7 @@
 #include <QObject>
 #include <QProcess>
 #include <QTextStream>
-#include <QTime>
+#include <QElapsedTimer>
 
 #include <solid-lite/soliddefs_p.h>
 
@@ -73,13 +73,13 @@ bool _k_isNetworkFileSystem(const QString &fstype, const QString &devName)
 void _k_updateMountPointsCache()
 {
     static bool firstCall = true;
-    static QTime elapsedTime;
+    static QElapsedTimer elapsedTimer;
 
     if (firstCall) {
         firstCall = false;
-        elapsedTime.start();
-    } else if (elapsedTime.elapsed()>10000) {
-        elapsedTime.restart();
+        elapsedTimer.start();
+    } else if (elapsedTimer.elapsed()>10000) {
+        elapsedTimer.restart();
     } else {
         return;
     }

--- a/db/librarydb.cpp
+++ b/db/librarydb.cpp
@@ -28,6 +28,7 @@
 #include <QSqlQuery>
 #include <QFile>
 #include <QRegExp>
+#include <QRandomGenerator>
 #include <QDebug>
 #include <algorithm>
 
@@ -1060,7 +1061,7 @@ LibraryDb::Album LibraryDb::getRandomAlbum(const QStringList &genres, const QStr
         return Album();
     }
 
-    return albums.at(Utils::random(albums.count()));
+    return albums.at(QRandomGenerator::global()->bounded(albums.count()));
 }
 
 QSet<QString> LibraryDb::get(const QString &type)

--- a/db/librarydb.cpp
+++ b/db/librarydb.cpp
@@ -1164,9 +1164,9 @@ bool LibraryDb::setFilter(const QString &f, const QString &genre)
                     int val=parts.at(0).simplified().toUInt();
                     if (val>=constMinYear && val<=constMaxYear) {
                         if (Song::useOriginalYear()) {
-                            year = QString().sprintf("( (origYear = %d) OR (origYear = 0 AND year = %d) )", val, val);
+                            year = QString("( (origYear = %1) OR (origYear = 0 AND year = %1) )").arg(val);
                         } else {
-                            year = QString().sprintf("year = %d", val);
+                            year = QString("year = %1").arg(val);
                         }
                         continue;
                     }
@@ -1175,10 +1175,10 @@ bool LibraryDb::setFilter(const QString &f, const QString &genre)
                     int to=parts.at(1).simplified().toUInt();
                     if (from>=constMinYear && from<=constMaxYear && to>=constMinYear && to<=constMaxYear) {
                         if (Song::useOriginalYear()) {
-                            year = QString().sprintf("( (origYear >= %d AND origYear <= %d) OR (origYear = 0 AND year >= %d AND year <= %d))",
-                                                     qMin(from, to), qMax(from, to), qMin(from, to), qMax(from, to));
+                            year = QString("( (origYear >= %1 AND origYear <= %2) OR (origYear = 0 AND year >= %1 AND year <= %2))")
+                                   .arg(qMin(from, to)).arg(qMax(from, to));
                         } else {
-                            year = QString().sprintf("year >= %d AND year <= %d", qMin(from, to), qMax(from, to));
+                            year = QString("year >= %1 AND year <= %2").arg(qMin(from, to)).arg(qMax(from, to));
                         }
                         continue;
                     }

--- a/devices/mtpdevice.cpp
+++ b/devices/mtpdevice.cpp
@@ -845,7 +845,7 @@ void MtpConnection::putSong(const Song &s, bool fixVa, const DeviceOptions &opts
             meta->composer=createString(song.composer());
             meta->genre=createString(song.genres[0]);
             meta->album=createString(song.album);
-            meta->date=createString(QString().sprintf("%4d0101T0000.0", song.year));
+            meta->date=createString(QStringLiteral("%1").arg(song.year, 4)+"0101T0000.0");
             meta->filename=createString(destName);
             meta->tracknumber=song.track;
             meta->duration=song.time*1000;

--- a/devices/musicbrainz.cpp
+++ b/devices/musicbrainz.cpp
@@ -27,8 +27,6 @@
 #include "network/networkproxyfactory.h"
 #include <QNetworkProxy>
 #include <QCryptographicHash>
-#include <cstdio>
-#include <cstring>
 #include <musicbrainz5/Query.h>
 #include <musicbrainz5/Medium.h>
 #include <musicbrainz5/Release.h>
@@ -83,12 +81,12 @@ static QString calculateDiscId(const QList<Track> &tracks)
     // Code based on libmusicbrainz/lib/diskid.cpp
     int numTracks = tracks.count()-1;
     QCryptographicHash sha(QCryptographicHash::Sha1);
-    char temp[9];
+    QString temp;
 
-    sprintf(temp, "%02X", 1);
-    sha.addData(temp, strlen(temp));
-    sprintf(temp, "%02X", numTracks);
-    sha.addData(temp, strlen(temp));
+    temp = QStringLiteral("%1").arg(1, 2, 16, QLatin1Char('0'));
+    sha.addData(temp.toUpper().toLatin1());
+    temp = QStringLiteral("%1").arg(numTracks, 2, 16, QLatin1Char('0'));
+    sha.addData(temp.toUpper().toLatin1());
 
     for(int i = 0; i < 100; i++) {
         int offset;
@@ -100,8 +98,8 @@ static QString calculateDiscId(const QList<Track> &tracks)
             offset = 0;
         }
 
-        sprintf(temp, "%08X", offset);
-        sha.addData(temp, strlen(temp));
+        temp = QStringLiteral("%1").arg(offset, 8, 16, QLatin1Char('0'));
+        sha.addData(temp.toUpper().toLatin1());
     }
 
     QByteArray base64 = sha.result().toBase64();

--- a/gui/application.cpp
+++ b/gui/application.cpp
@@ -88,7 +88,6 @@ void Application::init()
     // Ensure this is started before any MPD connection
     HttpServer::self();
 
-    Utils::initRand();
     Song::initTranslations();
 
     // Init sizes (before any widgets constructed!)

--- a/gui/librarypage.cpp
+++ b/gui/librarypage.cpp
@@ -28,12 +28,12 @@
 #include "settings.h"
 #include "stdactions.h"
 #include "customactions.h"
-#include "support/utils.h"
 #include "support/messagebox.h"
 #include "support/actioncollection.h"
 #include "models/mpdlibrarymodel.h"
 #include "widgets/menubutton.h"
 #include "widgets/genrecombo.h"
+#include <QRandomGenerator>
 
 LibraryPage::LibraryPage(QWidget *p)
     : SinglePageWidget(p)
@@ -401,7 +401,7 @@ void LibraryPage::addRandomAlbum()
     LibraryDb::Album album;
     if (!albums.isEmpty()) {
         // We have albums selected, so choose a random one of these...
-        SqlLibraryModel::AlbumItem *al=albums.at(Utils::random(albums.size()));
+        SqlLibraryModel::AlbumItem *al=albums.at(QRandomGenerator::global()->bounded(albums.size()));
         album.artist=al->getArtistId();
         album.id=al->getId();
     } else {

--- a/models/playqueuemodel.cpp
+++ b/models/playqueuemodel.cpp
@@ -63,6 +63,7 @@
 #include <QApplication>
 #include <QMenu>
 #include <QXmlStreamReader>
+#include <QRandomGenerator>
 #include <algorithm>
 
 GLOBAL_STATIC(PlayQueueModel, instance)
@@ -1610,7 +1611,7 @@ void PlayQueueModel::shuffleAlbums()
 
     QList<quint32> positions;
     while (!keys.isEmpty()) {
-        quint32 key=keys.takeAt(Utils::random(keys.count()));
+        quint32 key=keys.takeAt(QRandomGenerator::global()->bounded(keys.count()));
         QList<const Song *> albumSongs=albums[key];
         std::sort(albumSongs.begin(), albumSongs.end(), songSort);
         for (const Song *song: albumSongs) {

--- a/support/actioncollection.cpp
+++ b/support/actioncollection.cpp
@@ -133,7 +133,7 @@ QAction *ActionCollection::addAction(const QString &name, QAction *action) {
   else
     action->setObjectName(indexName);
   if(indexName.isEmpty())
-    indexName = indexName.sprintf("unnamed-%p", (void *)action);
+    indexName = QString::asprintf("unnamed-%p", (void *)action);
 
   // do we already have this action?
   if(_actionByName.value(indexName, nullptr) == action)

--- a/support/fancytabwidget.cpp
+++ b/support/fancytabwidget.cpp
@@ -377,7 +377,7 @@ void FancyTabBar::mousePressEvent(QMouseEvent *e)
 
 void FancyTabBar::wheelEvent(QWheelEvent *ev)
 {
-    int numDegrees = ev->delta() / 8;
+    int numDegrees = ev->angleDelta().y() / 8;
     int numSteps = numDegrees / -15;
     int prevIndex = currentIdx;
 

--- a/support/thread.cpp
+++ b/support/thread.cpp
@@ -23,7 +23,6 @@
 
 #include "thread.h"
 #include "globalstatic.h"
-#include "utils.h"
 #include <QCoreApplication>
 #include <QtGlobal>
 #include <QTimer>
@@ -108,7 +107,6 @@ Thread::~Thread()
 
 void Thread::run()
 {
-    Utils::initRand();
     QThread::run();
 }
 

--- a/support/utils.h
+++ b/support/utils.h
@@ -34,7 +34,6 @@
 #include <QFont>
 #include <QPainterPath>
 #include <stdlib.h>
-#include <QTime>
 
 class QString;
 class QWidget;
@@ -51,8 +50,6 @@ namespace Utils
     {
         return (fabs(d1 - d2) < precision);
     }
-    inline int random(int max=0) { return max ? (qrand()%max) : qrand(); }
-	inline void initRand() { QTime time = QTime::currentTime();	qsrand((time.second() * 1000) + (time.msec()));	}
 
     extern QString fixPath(const QString &d, bool ensureEndsInSlash=true);
     #ifdef Q_OS_WIN

--- a/tags/taghelperiface.cpp
+++ b/tags/taghelperiface.cpp
@@ -32,6 +32,7 @@
 #include <QApplication>
 #include <QLocalSocket>
 #include <QLocalServer>
+#include <QRandomGenerator>
 
 #include <QDebug>
 static bool debugEnabled=false;
@@ -302,7 +303,7 @@ bool TagHelperIface::startHelper()
         server=new QLocalServer(this);
 
         forever {
-            QString name="cantata-tags-"+QString::number(currentPid)+QLatin1Char('-')+QString::number(Utils::random());
+            QString name="cantata-tags-"+QString::number(currentPid)+QLatin1Char('-')+QString::number(QRandomGenerator::global()->generate());
             QLocalServer::removeServer(name);
             if (server->listen(name)) {
                 DBUG << "Listening on" << server->fullServerName();

--- a/translations/blank.ts
+++ b/translations/blank.ts
@@ -4046,12 +4046,22 @@ This cannot be undone.</source>
         <source>Now Playing</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../widgets/nowplayingwidget.cpp" line="459"/>
+        <source>%1 kb/s</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message numerus="yes">
         <location filename="../widgets/nowplayingwidget.cpp" line="465"/>
         <source>%n bit</source>
         <translation type="unfinished">
             <numerusform></numerusform>
         </translation>
+    </message>
+    <message>
+        <location filename="../widgets/nowplayingwidget.cpp" line="471"/>
+        <source>%1 kHz</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/cantata_cs.ts
+++ b/translations/cantata_cs.ts
@@ -10565,6 +10565,11 @@ Tento krok nelze vrátit zpět.</translation>
         <source>Now Playing</source>
         <translation>Nyní se hraje</translation>
     </message>
+    <message>
+        <location filename="../widgets/nowplayingwidget.cpp" line="459"/>
+        <source>%1 kb/s</source>
+        <translation>%1 kb/s</translation>
+    </message>
     <message numerus="yes">
         <location filename="../widgets/nowplayingwidget.cpp" line="465"/>
         <source>%n bit</source>
@@ -10573,6 +10578,11 @@ Tento krok nelze vrátit zpět.</translation>
             <numerusform>%n bity</numerusform>
             <numerusform>%n bitů</numerusform>
         </translation>
+    </message>
+    <message>
+        <location filename="../widgets/nowplayingwidget.cpp" line="471"/>
+        <source>%1 kHz</source>
+        <translation>%1 kHz</translation>
     </message>
     <message>
         <source>(Stream)</source>

--- a/translations/cantata_da.ts
+++ b/translations/cantata_da.ts
@@ -4135,6 +4135,11 @@ Det kan ikke fortrydes.</translation>
         <source>Now Playing</source>
         <translation>Afspiller nu</translation>
     </message>
+    <message>
+        <location filename="../widgets/nowplayingwidget.cpp" line="459"/>
+        <source>%1 kb/s</source>
+        <translation>%1 kb/s</translation>
+    </message>
     <message numerus="yes">
         <location filename="../widgets/nowplayingwidget.cpp" line="465"/>
         <source>%n bit</source>
@@ -4142,6 +4147,11 @@ Det kan ikke fortrydes.</translation>
             <numerusform>%n bit</numerusform>
             <numerusform></numerusform>
         </translation>
+    </message>
+    <message>
+        <location filename="../widgets/nowplayingwidget.cpp" line="471"/>
+        <source>%1 kHz</source>
+        <translation>%1 kHz</translation>
     </message>
 </context>
 <context>

--- a/translations/cantata_de.ts
+++ b/translations/cantata_de.ts
@@ -8396,6 +8396,11 @@ Dies kann nicht rückgängig gemacht werden.</translation>
         <source>Now Playing</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../widgets/nowplayingwidget.cpp" line="459"/>
+        <source>%1 kb/s</source>
+        <translation>%1 kb/s</translation>
+    </message>
     <message numerus="yes">
         <location filename="../widgets/nowplayingwidget.cpp" line="465"/>
         <source>%n bit</source>
@@ -8403,6 +8408,11 @@ Dies kann nicht rückgängig gemacht werden.</translation>
             <numerusform></numerusform>
             <numerusform></numerusform>
         </translation>
+    </message>
+    <message>
+        <location filename="../widgets/nowplayingwidget.cpp" line="471"/>
+        <source>%1 kHz</source>
+        <translation>%1 kHz</translation>
     </message>
     <message>
         <source>(Stream)</source>

--- a/translations/cantata_en_GB.ts
+++ b/translations/cantata_en_GB.ts
@@ -4146,6 +4146,11 @@ This cannot be undone.</source>
         <source>Now Playing</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../widgets/nowplayingwidget.cpp" line="459"/>
+        <source>%1 kb/s</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message numerus="yes">
         <location filename="../widgets/nowplayingwidget.cpp" line="465"/>
         <source>%n bit</source>
@@ -4153,6 +4158,11 @@ This cannot be undone.</source>
             <numerusform></numerusform>
             <numerusform></numerusform>
         </translation>
+    </message>
+    <message>
+        <location filename="../widgets/nowplayingwidget.cpp" line="471"/>
+        <source>%1 kHz</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/cantata_es.ts
+++ b/translations/cantata_es.ts
@@ -9013,6 +9013,11 @@ This cannot be undone.</source>
         <source>Now Playing</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../widgets/nowplayingwidget.cpp" line="459"/>
+        <source>%1 kb/s</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message numerus="yes">
         <location filename="../widgets/nowplayingwidget.cpp" line="465"/>
         <source>%n bit</source>
@@ -9020,6 +9025,11 @@ This cannot be undone.</source>
             <numerusform></numerusform>
             <numerusform></numerusform>
         </translation>
+    </message>
+    <message>
+        <location filename="../widgets/nowplayingwidget.cpp" line="471"/>
+        <source>%1 kHz</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>(Stream)</source>

--- a/translations/cantata_fi.ts
+++ b/translations/cantata_fi.ts
@@ -4116,6 +4116,11 @@ Tätä ei voi kumota.</translation>
         <source>Now Playing</source>
         <translation>Nyt soi</translation>
     </message>
+    <message>
+        <location filename="../widgets/nowplayingwidget.cpp" line="459"/>
+        <source>%1 kb/s</source>
+        <translation>%1 kb/s</translation>
+    </message>
     <message numerus="yes">
         <location filename="../widgets/nowplayingwidget.cpp" line="465"/>
         <source>%n bit</source>
@@ -4123,6 +4128,11 @@ Tätä ei voi kumota.</translation>
             <numerusform></numerusform>
             <numerusform></numerusform>
         </translation>
+    <message>
+        <location filename="../widgets/nowplayingwidget.cpp" line="471"/>
+        <source>%1 kHz</source>
+        <translation>%1 kHz</translation>
+    </message>
     </message>
 </context>
 <context>

--- a/translations/cantata_fr.ts
+++ b/translations/cantata_fr.ts
@@ -9379,6 +9379,11 @@ Cette action est définitive.</translation>
         <source>Now Playing</source>
         <translation>En cours</translation>
     </message>
+    <message>
+        <location filename="../widgets/nowplayingwidget.cpp" line="459"/>
+        <source>%1 kb/s</source>
+        <translation>%1 kb/s</translation>
+    </message>
     <message numerus="yes">
         <location filename="../widgets/nowplayingwidget.cpp" line="465"/>
         <source>%n bit</source>
@@ -9386,6 +9391,11 @@ Cette action est définitive.</translation>
             <numerusform></numerusform>
             <numerusform></numerusform>
         </translation>
+    </message>
+    <message>
+        <location filename="../widgets/nowplayingwidget.cpp" line="471"/>
+        <source>%1 kHz</source>
+        <translation>%1 kHz</translation>
     </message>
     <message>
         <source>(Stream)</source>

--- a/translations/cantata_hu.ts
+++ b/translations/cantata_hu.ts
@@ -9889,12 +9889,22 @@ Ezt nem lehet visszavonni!</translation>
         <source>Now Playing</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../widgets/nowplayingwidget.cpp" line="459"/>
+        <source>%1 kb/s</source>
+        <translation type="unfinished">%1 kb/s</translation>
+    </message>
     <message numerus="yes">
         <location filename="../widgets/nowplayingwidget.cpp" line="465"/>
         <source>%n bit</source>
         <translation type="unfinished">
             <numerusform></numerusform>
         </translation>
+    </message>
+    <message>
+        <location filename="../widgets/nowplayingwidget.cpp" line="471"/>
+        <source>%1 kHz</source>
+        <translation type="unfinished">%1 kHz</translation>
     </message>
     <message>
         <source>(Stream)</source>

--- a/translations/cantata_it.ts
+++ b/translations/cantata_it.ts
@@ -4257,6 +4257,11 @@ Non sarà possibile tornare indietro.</translation>
         <source>Now Playing</source>
         <translation>In riproduzione</translation>
     </message>
+    <message>
+        <location filename="../widgets/nowplayingwidget.cpp" line="459"/>
+        <source>%1 kb/s</source>
+        <translation>%1 kb/s</translation>
+    </message>
     <message numerus="yes">
         <location filename="../widgets/nowplayingwidget.cpp" line="465"/>
         <source>%n bit</source>
@@ -4264,6 +4269,11 @@ Non sarà possibile tornare indietro.</translation>
             <numerusform></numerusform>
             <numerusform></numerusform>
         </translation>
+    </message>
+    <message>
+        <location filename="../widgets/nowplayingwidget.cpp" line="471"/>
+        <source>%1 kHz</source>
+        <translation>%1 kHz</translation>
     </message>
     <message>
         <source>(Stream)</source>

--- a/translations/cantata_ja.ts
+++ b/translations/cantata_ja.ts
@@ -4107,12 +4107,22 @@ This cannot be undone.</source>
         <source>Now Playing</source>
         <translation>現在再生中</translation>
     </message>
+    <message>
+        <location filename="../widgets/nowplayingwidget.cpp" line="459"/>
+        <source>%1 kb/s</source>
+        <translation>%1 kb/s</translation>
+    </message>
     <message numerus="yes">
         <location filename="../widgets/nowplayingwidget.cpp" line="465"/>
         <source>%n bit</source>
         <translation type="unfinished">
             <numerusform></numerusform>
         </translation>
+    </message>
+    <message>
+        <location filename="../widgets/nowplayingwidget.cpp" line="471"/>
+        <source>%1 kHz</source>
+        <translation>%1 kHz</translation>
     </message>
 </context>
 <context>

--- a/translations/cantata_ko.ts
+++ b/translations/cantata_ko.ts
@@ -10515,12 +10515,22 @@ This cannot be undone.</source>
         <source>Now Playing</source>
         <translation type="unfinished">지금 연주 중</translation>
     </message>
+    <message>
+        <location filename="../widgets/nowplayingwidget.cpp" line="459"/>
+        <source>%1 kb/s</source>
+        <translation type="unfinished">%1 kb/s</translation>
+    </message>
     <message numerus="yes">
         <location filename="../widgets/nowplayingwidget.cpp" line="465"/>
         <source>%n bit</source>
         <translation type="unfinished">
             <numerusform>%n 비트</numerusform>
         </translation>
+    </message>
+    <message>
+        <location filename="../widgets/nowplayingwidget.cpp" line="471"/>
+        <source>%1 kHz</source>
+        <translation type="unfinished">%1 kHz</translation>
     </message>
     <message>
         <source>(Stream)</source>

--- a/translations/cantata_nl.ts
+++ b/translations/cantata_nl.ts
@@ -4117,6 +4117,11 @@ Dit kan niet ongedaan worden gemaakt.</translation>
         <source>Now Playing</source>
         <translation>Nu aan het afspelen</translation>
     </message>
+    <message>
+        <location filename="../widgets/nowplayingwidget.cpp" line="459"/>
+        <source>%1 kb/s</source>
+        <translation>%1 kb/s</translation>
+    </message>
     <message numerus="yes">
         <location filename="../widgets/nowplayingwidget.cpp" line="465"/>
         <source>%n bit</source>
@@ -4124,6 +4129,11 @@ Dit kan niet ongedaan worden gemaakt.</translation>
             <numerusform></numerusform>
             <numerusform></numerusform>
         </translation>
+    </message>
+    <message>
+        <location filename="../widgets/nowplayingwidget.cpp" line="471"/>
+        <source>%1 kHz</source>
+        <translation>%1 kHz</translation>
     </message>
 </context>
 <context>

--- a/translations/cantata_pl.ts
+++ b/translations/cantata_pl.ts
@@ -10587,6 +10587,11 @@ Ta operacja nie może być cofnięta.</translation>
         <source>Now Playing</source>
         <translation>Teraz odtwarzane</translation>
     </message>
+    <message>
+        <location filename="../widgets/nowplayingwidget.cpp" line="459"/>
+        <source>%1 kb/s</source>
+        <translation>%1 kb/s</translation>
+    </message>
     <message numerus="yes">
         <location filename="../widgets/nowplayingwidget.cpp" line="465"/>
         <source>%n bit</source>
@@ -10595,6 +10600,11 @@ Ta operacja nie może być cofnięta.</translation>
             <numerusform></numerusform>
             <numerusform></numerusform>
         </translation>
+    </message>
+    <message>
+        <location filename="../widgets/nowplayingwidget.cpp" line="471"/>
+        <source>%1 kHz</source>
+        <translation>%1 kHz</translation>
     </message>
     <message>
         <source>(Stream)</source>

--- a/translations/cantata_pt_BR.ts
+++ b/translations/cantata_pt_BR.ts
@@ -3200,12 +3200,20 @@ Não será possível desfazer esta escolha.</translation>
         <source>Now Playing</source>
         <translation>Em reprodução</translation>
     </message>
+    <message>
+        <source>%1 kb/s</source>
+        <translation>%1 kb/s</translation>
+    </message>
     <message numerus="yes">
         <source>%n bit</source>
         <translation type="unfinished">
             <numerusform></numerusform>
             <numerusform></numerusform>
         </translation>
+    </message>
+    <message>
+        <source>%1 kHz</source>
+        <translation>%1 kHz</translation>
     </message>
 </context>
 <context>

--- a/translations/cantata_ru.ts
+++ b/translations/cantata_ru.ts
@@ -9921,6 +9921,11 @@ This cannot be undone.</source>
         <source>Now Playing</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../widgets/nowplayingwidget.cpp" line="459"/>
+        <source>%1 kb/s</source>
+        <translation type="unfinished">%1 кбит/с</translation>
+    </message>
     <message numerus="yes">
         <location filename="../widgets/nowplayingwidget.cpp" line="465"/>
         <source>%n bit</source>
@@ -9929,6 +9934,11 @@ This cannot be undone.</source>
             <numerusform></numerusform>
             <numerusform></numerusform>
         </translation>
+    </message>
+    <message>
+        <location filename="../widgets/nowplayingwidget.cpp" line="471"/>
+        <source>%1 kHz</source>
+        <translation type="unfinished">%1 кГц</translation>
     </message>
     <message>
         <source>(Stream)</source>

--- a/translations/cantata_zh_CN.ts
+++ b/translations/cantata_zh_CN.ts
@@ -6529,12 +6529,22 @@ This cannot be undone.</source>
         <source>Now Playing</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../widgets/nowplayingwidget.cpp" line="459"/>
+        <source>%1 kb/s</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message numerus="yes">
         <location filename="../widgets/nowplayingwidget.cpp" line="465"/>
         <source>%n bit</source>
         <translation type="unfinished">
             <numerusform></numerusform>
         </translation>
+    </message>
+    <message>
+        <location filename="../widgets/nowplayingwidget.cpp" line="471"/>
+        <source>%1 kHz</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>(Stream)</source>

--- a/widgets/nowplayingwidget.cpp
+++ b/widgets/nowplayingwidget.cpp
@@ -456,7 +456,7 @@ void NowPlayingWidget::updateInfo()
 
     QString info;
     if (MPDStatus::self()->bitrate()>0) {
-        info += QString().sprintf("%d kbps", MPDStatus::self()->bitrate());
+        info += tr("%1 kb/s").arg(MPDStatus::self()->bitrate());
     }
     if (MPDStatus::self()->bits()>0) {
         if (!info.isEmpty()) {
@@ -468,7 +468,7 @@ void NowPlayingWidget::updateInfo()
         if (!info.isEmpty()) {
             info+=", ";
         }
-        info += QString().sprintf("%.1f kHz", MPDStatus::self()->samplerate()/1000.0);
+        info += tr("%1 kHz").arg(MPDStatus::self()->samplerate()/1000.0, 0, 'f', 1);
     }
 
     int pos=currentSongFile.lastIndexOf('.');

--- a/widgets/nowplayingwidget.cpp
+++ b/widgets/nowplayingwidget.cpp
@@ -345,7 +345,7 @@ void NowPlayingWidget::startTimer()
         timer->setInterval(1000);
         connect(timer, SIGNAL(timeout()), this, SLOT(updatePos()));
     }
-    startTime.restart();
+    elapsedTimer.start();
     lastVal=value();
     timer->start();
     pollCount=0;
@@ -362,7 +362,7 @@ void NowPlayingWidget::stopTimer()
 void NowPlayingWidget::setValue(int v)
 {
     if (qAbs(v-slider->value())>1 || MPDState_Playing!=MPDStatus::self()->state()) {
-        startTime.restart();
+        elapsedTimer.start();
         lastVal=v;
         slider->setValue(v);
         updateTimes();
@@ -418,7 +418,7 @@ void NowPlayingWidget::updateTimes()
 
 void NowPlayingWidget::updatePos()
 {
-    quint16 elapsed=(startTime.elapsed()/1000.0)+0.5;
+    quint16 elapsed=(elapsedTimer.elapsed()/1000.0)+0.5;
     slider->setValue(lastVal+elapsed);
     MPDStatus::self()->setGuessedElapsed(lastVal+elapsed);
     if (++pollCount>=constPollMpd) {

--- a/widgets/nowplayingwidget.h
+++ b/widgets/nowplayingwidget.h
@@ -25,7 +25,7 @@
 #define NOWPLAYING_WIDGET_H
 
 #include <QWidget>
-#include <QTime>
+#include <QElapsedTimer>
 #include <QSlider>
 #include "support/squeezedtextlabel.h"
 
@@ -101,7 +101,7 @@ private:
     PosSlider *slider;
     RatingWidget *ratingWidget;
     QTimer *timer;
-    QTime startTime;
+    QElapsedTimer elapsedTimer;
     QString currentSongFile;
     int lastVal;
     int pollCount;


### PR DESCRIPTION
All changes are done in a way that Cantata still compiles with Qt 5.11. The translations if available have been copied from `songview.cpp`.