### PR TITLE
Fix #1627: Check for includeUnrated in Dynamic Playlists with rating and include rules

### DIFF
--- a/playlists/cantata-dynamic
+++ b/playlists/cantata-dynamic
@@ -465,9 +465,7 @@ sub readRules() {
                             }
                         }
                     } elsif ($key=~ m/^(IncludeUnrated)/) {
-                        if ($val > 0) {
-                            $includeUnrated = $val eq "true";
-                        }
+                        $includeUnrated = $val eq "true";
                     } elsif ($key=~ m/^(Duration)/) {
                         my @vals = split("-", $val);
                         if (scalar(@vals)==2) {
@@ -681,6 +679,9 @@ sub checkSongRatingInRange() {
     }
     my $file=shift;
     my @entries = &getEntries("sticker get song \"${file}\" rating", 'sticker');
+    if (@entries == 0 && $includeUnrated == 1) { # Song has no ratings, and unrated songs are included!
+        return 1;
+    }
     foreach my $entry (@entries) {
         if (1==&songRatingInRange($entry)) {
             return 1;


### PR DESCRIPTION
This fixes #1627 on my machine. Dynamic Playlists that look like this now include unrated songs:

![dynamic-playlist-settings](https://user-images.githubusercontent.com/852873/88888900-05567900-d1f4-11ea-8d51-97b731f1ffca.png)

This does not handle Dynamic Playlists with rating rules but no include/exclude rules ([separate flow](https://github.com/CDrummond/cantata/blob/master/playlists/cantata-dynamic#L761), I'm not sure if unrated songs are [included here](https://github.com/CDrummond/cantata/blob/master/playlists/cantata-dynamic#L645))

My first time writing Perl, let me know if I wrote something "non-Perlonic" :sweat_smile: 