### PR TITLE
Fix typo in Czech translation

### DIFF
--- a/translations/cantata_cs.ts
+++ b/translations/cantata_cs.ts
@@ -5236,7 +5236,7 @@ i18n: ectx: property (text), widget (QLabel, ratingVarious)
         <extracomment>i18n: file: tags/tageditor.ui:210
 i18n: ectx: property (text), widget (PlainNoteLabel, label_7x)
 </extracomment>
-        <translation type="vanished">Více žánrů se musí oddělit čárkou (např. &apos;Rock;Hard Rock&apos;)</translation>
+        <translation type="vanished">Více žánrů se musí oddělit čárkou (např. &apos;Rock,Hard Rock&apos;)</translation>
     </message>
     <message>
         <source>Ratings are stored in an external database, and &lt;b&gt;not&lt;/b&gt; in the song&apos;s file.</source>


### PR DESCRIPTION
Multiple genres example in tag editor used semicolon instead of comma.