### PR TITLE
Fix ogg opus file type confusion in cantata-tags

### DIFF
--- a/tags/filetyperesolver.cpp
+++ b/tags/filetyperesolver.cpp
@@ -66,16 +66,16 @@ TagLib::File *Meta::Tag::FileTypeResolver::createFile(TagLib::FileName fileName,
             delete result;
             result = new TagLib::Ogg::FLAC::File(fileName, readProperties, propertiesStyle);
         }
-        if (!result->isValid()) {
-            delete result;
-            result = new TagLib::TrueAudio::File(fileName, readProperties, propertiesStyle);
-        }
         #ifdef TAGLIB_OPUS_FOUND
         if (!result->isValid()) {
             delete result;
             result = new TagLib::Ogg::Opus::File(fileName, readProperties, propertiesStyle);
         }
         #endif
+        if (!result->isValid()) {
+            delete result;
+            result = new TagLib::TrueAudio::File(fileName, readProperties, propertiesStyle);
+        }
     } else if (suffix == QLatin1String("m4a") || suffix == QLatin1String("m4b")
         || suffix == QLatin1String("m4p") || suffix == QLatin1String("mp4")
         /*|| suffix == QLatin1String("m4v") || suffix == QLatin1String("mp4v") */) {

--- a/tags/filetyperesolver.h
+++ b/tags/filetyperesolver.h
@@ -24,6 +24,7 @@
 #ifndef AMAROK_FILETYPERESOLVER_H
 #define AMAROK_FILETYPERESOLVER_H
 
+#include "config.h"
 #include <taglib/fileref.h>
 
 namespace Meta


### PR DESCRIPTION
The taglib True Audio loader seems to erroneously accept ogg-contained opus files. This results in ID3 tags being written to ogg opus files. This is especially apparent when using replaygain, as ID3 RVA2 and `replaygain_track_gain` tags are written instead of `R128_TRACK_GAIN`. 

Existing wrongly-tagged files can have their ID3 tags removed using something like `mutagen`, with
```python3
import mutagen.id3
mutagen.id3.ID3('/path/to/file.ogg').delete()
```

I have not tested this against TrueAudio files. It is possible that the opus loader will consider True Audio files valid.