### PR TITLE
Fix wizard window on smaller screens

### DIFF
--- a/gui/findmpddialog.cpp
+++ b/gui/findmpddialog.cpp
@@ -16,7 +16,9 @@
  */
 
 #include "findmpddialog.h"
+#include "support/utils.h"
 #include <QPushButton>
+#include <QScreen>
 
 FindMpdDialog::FindMpdDialog(QWidget *p)
     : QDialog(p)
@@ -28,7 +30,6 @@ FindMpdDialog::FindMpdDialog(QWidget *p)
     tableWidget->setHorizontalHeaderLabels({tr("Name"), tr("Address"), tr("Port")});
     tableWidget->resizeColumnToContents(0);
     tableWidget->resizeColumnToContents(1);
-
     QObject::connect(avahi.data(), &AvahiDiscovery::mpdFound, this, &FindMpdDialog::addMpd);
     QObject::connect(avahi.data(), &AvahiDiscovery::mpdRemoved, this, &FindMpdDialog::removeMpd);
     QObject::connect(this, &QDialog::accepted, this, &FindMpdDialog::okClicked);

--- a/gui/findmpddialog.ui
+++ b/gui/findmpddialog.ui
@@ -12,8 +12,8 @@
   </property>
   <property name="minimumSize">
    <size>
-    <width>470</width>
-    <height>300</height>
+    <width>0</width>
+    <height>0</height>
    </size>
   </property>
   <property name="windowTitle">

--- a/gui/initialsettingswizard.cpp
+++ b/gui/initialsettingswizard.cpp
@@ -38,6 +38,7 @@
 #include <QDir>
 #include <QStandardPaths>
 #include <QTimer>
+#include <QScreen>
 
 enum Pages {
     PAGE_INTRO,
@@ -104,8 +105,8 @@ InitialSettingsWizard::InitialSettingsWizard(QWidget *p)
     if (sz.height()>(sz.width()*(highDpi ? 1.125 : 1.2))) {
         sz+=QSize(sz.height()*(highDpi ? 0.4 : 0.25), -(sz.height()*(highDpi ? 0.1 : 0.25)));
     }
-    resize(sz);
-    setMinimumSize(sz);
+    QSize screenSize = QApplication::primaryScreen()->availableSize();
+    resize(Utils::minSize(sz, screenSize));
     #endif
 
     #ifdef AVAHI_FOUND

--- a/support/utils.cpp
+++ b/support/utils.cpp
@@ -1058,3 +1058,6 @@ void Utils::raiseWindow(QWidget *w)
     #endif
 }
 
+QSize Utils::minSize(const QSize &fst, const QSize &snd) {
+    return QSize(std::min(fst.width(), snd.width()), std::min(fst.height(), snd.height()));
+}

--- a/support/utils.h
+++ b/support/utils.h
@@ -111,6 +111,7 @@ namespace Utils
     extern bool limitedHeight(QWidget *w);
     extern void resizeWindow(QWidget *w, bool preserveWidth=true, bool preserveHeight=true);
     extern void raiseWindow(QWidget *w);
+    extern QSize minSize(const QSize &fst, const QSize &snd);
 
     enum Desktop {
         KDE,


### PR DESCRIPTION
This makes the whole wizard window usable on PinePhone.

Main GUI works quite well, but I plan to tweak it a bit in the future, because scrolling is very problematic. I also removed usage of some deprecated functions in other branch, but it increased minimal required Qt version to 5.14. I can open another PR if that's acceptable.