### PR TITLE
Replace &mdash; in wikipedia description

### DIFF
--- a/context/wikipediaengine.cpp
+++ b/context/wikipediaengine.cpp
@@ -249,6 +249,7 @@ static QString wikiToHtml(QString answer, bool introOnly, const QUrl &url)
     }
     answer.replace("&amp;nbsp;", " ");
     answer.replace("&ndash;", "-");
+    answer.replace("&amp;mdash;", "—");
     answer.replace("<br><h", "<h");
     if (introOnly) {
         end=answer.indexOf("==", 3);


### PR DESCRIPTION
From Gojira's description:
![image](https://user-images.githubusercontent.com/31708910/109390457-0c707180-7912-11eb-9bc0-fce06e2da793.png)
