### PR TITLE
Fix Album, Artist and Song overlap on sidebar resize

### DIFF
--- a/context/contextwidget.cpp
+++ b/context/contextwidget.cpp
@@ -269,7 +269,7 @@ ContextWidget::ContextWidget(QWidget *parent)
     artist = new ArtistView(standardContext);
     album = new AlbumView(standardContext);
     song = new SongView(standardContext);
-    minWidth=album->picSize().width()*2.5;
+    minWidth=album->width()+artist->width()+song->width();
 
     artist->addEventFilter(this);
     album->addEventFilter(this);


### PR DESCRIPTION
I am unsure why the picSize*2.5 calculation was used in the first place and maybe this is only an issue with my setup/dpi, however this patch fixed it for me. Someone else might need to verify.
before:
![before](https://user-images.githubusercontent.com/31708910/109500745-eaecc280-7a96-11eb-908b-bcb2fb6c86da.gif)
after:
![after](https://user-images.githubusercontent.com/31708910/109500761-f0e2a380-7a96-11eb-8b24-771d3cc704c5.gif)
