### PR TITLE
Fix serverType becoming undetermined on waking from suspend

### DIFF
--- a/mpd-interface/mpdconnection.cpp
+++ b/mpd-interface/mpdconnection.cpp
@@ -536,6 +536,7 @@ void MPDConnection::reconnect()
         if (replaygainSupported() && details.applyReplayGain && !details.replayGain.isEmpty()) {
             sendCommand("replay_gain_mode "+details.replayGain.toLatin1());
         }
+        serverInfo.detect();
         listPartitions();
         getStatus();
         getStats();


### PR DESCRIPTION
This was causing the partitions menu to disappear every time the computer went to sleep.