### PR TITLE
Allow refreshing lyrics if the lyrics file doesn't exist

### DIFF
--- a/context/songview.cpp
+++ b/context/songview.cpp
@@ -915,7 +915,6 @@ void SongView::setMode(Mode m)
     mode=m;
     bool fileExists=Mode_Display==m && !lyricsFile.isEmpty() && QFileInfo(lyricsFile).isWritable();
     delAction->setEnabled(fileExists);
-    refreshAction->setEnabled(fileExists);
     if (scrollAction->isChecked()) {
         if (Mode_Display==mode) {
             scroll();


### PR DESCRIPTION
If a previous fetch from webproviders failed for some reason or the user manually updates the lyrics file it makes sense to allow refreshes even if the lyrics file doesn't exist yet.