### PR TITLE
Allow sorting a playqueue by filename/path

### DIFF
--- a/models/playqueuemodel.cpp
+++ b/models/playqueuemodel.cpp
@@ -82,6 +82,7 @@ static const QLatin1String constSortByComposerKey("composer");
 static const QLatin1String constSortByPerformerKey("performer");
 static const QLatin1String constSortByTitleKey("title");
 static const QLatin1String constSortByNumberKey("track");
+static const QLatin1String constSortByPathKey("path");
 
 static QSet<QString> constM3uPlaylists = QSet<QString>() << QLatin1String("m3u") << QLatin1String("m3u8");
 static const QString constPlsPlaylist = QLatin1String("pls");
@@ -459,6 +460,7 @@ PlayQueueModel::PlayQueueModel(QObject *parent)
     addSortAction(tr("Year"), constSortByYearKey);
     addSortAction(tr("Composer"), constSortByComposerKey);
     addSortAction(tr("Performer"), constSortByPerformerKey);
+    addSortAction(tr("Path"), constSortByPathKey);
     controlActions();
     shuffleAction->setEnabled(false);
     sortAction->setEnabled(false);
@@ -1457,6 +1459,12 @@ static bool trackSort(const Song *s1, const Song *s2)
     return s1->track<s2->track || (s1->track==s2->track && (*s1)<(*s2));
 }
 
+static bool pathSort(const Song *s1, const Song *s2)
+{
+    int c=s1->file.localeAwareCompare(s2->file);
+    return c<0 || (c==0 && (*s1)<(*s2));
+}
+
 void PlayQueueModel::sortBy()
 {
     Action *act=qobject_cast<Action *>(sender());
@@ -1486,6 +1494,8 @@ void PlayQueueModel::sortBy()
             std::sort(copy.begin(), copy.end(), titleSort);
         } else if (constSortByNumberKey==key) {
             std::sort(copy.begin(), copy.end(), trackSort);
+        } else if (constSortByPathKey==key) {
+            std::sort(copy.begin(), copy.end(), pathSort);
         }
         QList<quint32> positions;
         for (const Song *s: copy) {


### PR DESCRIPTION
Hey, I wanted this feature for my personal use - feel free to close if you're not interested in upstreaming it :sweat_smile: 

I have a collection of low-quality metadata files like:

- SomeAlbum/1001_SongA.mp3 (Album: `SomeAlbum`, Title: `Song A`, Track Number: `1`)
- SomeAlbum/1002_SongB.mp3 (Album: `SomeAlbum`, Title: `Song B`, Track Number: `2`)
- SomeAlbum/2001_SongA.mp3 (Album: `SomeAlbum`, Title: `Song A`, Track Number: `1`)
- SomeAlbum/2002_SongB.mp3 (Album: `SomeAlbum`, Title: `Song B`, Track Number: `2`)

Ideally, these tracks would either be in separate albums (`SomeAlbum Part 1`, `SomeAlbum Part 2`) or have proper non-overlapping track numbers, but this is not the case. The easiest way to play them in order without modifying the source files is to sort them by filename. I've added this as a sort option (which was surprisingly easy to do!):

https://user-images.githubusercontent.com/852873/124843735-71367b00-df47-11eb-848b-25ac402f24e7.mp4

I wasn't sure what to use as a translation key. I believe `Filename` appears in the translation .ts files but I'm not 100% sure how they work. Let me know if I did anything too wacky.

Cheers!

