### PR TITLE
Fix build with musl libc - require sys/types.h for dev_t unconditionally

### DIFF
--- a/3rdparty/solid-lite/backends/udisks2/udisksblock.h
+++ b/3rdparty/solid-lite/backends/udisks2/udisksblock.h
@@ -24,6 +24,8 @@
 #include <solid-lite/ifaces/block.h>
 #include "udisksdeviceinterface.h"
 
+#include <sys/types.h> // dev_t
+
 namespace Solid
 {
 namespace Backends


### PR DESCRIPTION
> Fixes a build error with musl libc.  Turns out this is the required
> header for dev_t, and not just for FreeBSD.  That it works without on
> glibc is just an accident.
> 
> Differential Revision: https://phabricator.kde.org/D6596
> 
> (cherry picked from commit 2382c3f8d3669c473130f4baefb68d244dcb5cbc)

Patch picked from upstream solid.

See also downstream report: https://bugs.gentoo.org/792555

Is there any appetite to support upstream KF5Solid in cantata?