### PR TITLE
Updated README for macOS when qt5 and qt6 are both installed with homebrew

### DIFF
--- a/README
+++ b/README
@@ -815,11 +815,27 @@ Build via QtCreator
 Build via commandline
 ---------------------
 
+If you have qt6 installed as well as qt5 (installed above), then homebrew
+calls qt6 "qt". Since we need to build Cantata against qt5, the easiest
+option is to temporarily unlink qt6 and link qt5, then undo the process.
+
+If you have qt6 installed (check version in "brew info qt"), then do this:
+
+    brew unlink qt@6
+    brew link qt@5
+
+Build and install Cantata:
+
     cd build
     export Qt5_DIR="/usr/local/opt/qt5/lib/cmake"
     cmake -S "../src" -B "./" -DCMAKE_INSTALL_PREFIX="../install" -DENABLE_TAGLIB=ON -DCMAKE_PREFIX_PATH="/usr/local/opt/qt5/;/usr/local/opt/qt5/lib/cmake/Qt5Widgets/" -DCMAKE_BUILD_TYPE=Release
     make
     make install
+
+Finally, relink the original qt6 (again, if you had qt6 at all):
+
+    brew unlink qt@5
+    brew link qt@6
 
 
 Create Installer


### PR DESCRIPTION
Hi there.

I thought I would offer this small change to the `README` in the case of macOS when homebrew has both qt5 and qt6 installed.

`make` fails if qt6 is linked. The output suggests that it is indeed finding qt5, and using that for most things, but at some point there are files from the default `/usr/local/include` that get pulled in nonetheless. They belong to qt6, and cause errors. However hard I tried to fix `CMAKE_PREFIX_PATH`, or other environment variables (including all those suggested in the "caveat" that `brew info qt5` prints when qt6 is installed), I couldn't get it to build.

Simply unlinking then relinking via homebrew works fine, and is probably not too unreasonable a thing to do in such circumstances, allthough I admit, it is not very elegant…