### PR TITLE
Fix tag editor window width issue

### DIFF
--- a/tags/tageditor.ui
+++ b/tags/tageditor.ui
@@ -72,7 +72,11 @@
       </widget>
      </item>
      <item row="2" column="1">
-      <widget class="CompletionCombo" name="artist"/>
+      <widget class="CompletionCombo" name="artist">
+       <property name="sizeAdjustPolicy">                                                                                     
+        <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>                                                         
+       </property>                                                                                                            
+      </widget> 
      </item>
      <item row="3" column="0">
       <widget class="StateLabel" name="albumArtistLabel">
@@ -98,7 +102,11 @@
       </widget>
      </item>
      <item row="4" column="1">
-      <widget class="CompletionCombo" name="composer"/>
+      <widget class="CompletionCombo" name="composer">
+       <property name="sizeAdjustPolicy">                                                                                     
+        <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>                                                         
+       </property>                                                                                                            
+      </widget>
      </item>
      <item row="5" column="0">
       <widget class="StateLabel" name="albumLabel">


### PR DESCRIPTION
The artist and composer combo boxes can grow extremely wide for some tracks causing the tag editor window to span nearly the entire width of the screen.  Adding the AdjustToMinimumContentsLengthWithIcon property for these two combo boxes fixes the window from growing too wide but keeps the ability to view long artists and composers.