### PR TITLE
Add ability to disable/enable volume control slider

### DIFF
--- a/gui/interfacesettings.cpp
+++ b/gui/interfacesettings.cpp
@@ -263,6 +263,7 @@ void InterfaceSettings::load()
     forceSingleClick->setChecked(Settings::self()->forceSingleClick());
     infoTooltips->setChecked(Settings::self()->infoTooltips());
     showStopButton->setChecked(Settings::self()->showStopButton());
+    showVolumeSlider->setChecked(Settings::self()->showVolumeSlider());
     showCoverWidget->setChecked(Settings::self()->showCoverWidget());
     showRatingWidget->setChecked(Settings::self()->showRatingWidget());
     showTechnicalInfo->setChecked(Settings::self()->showTechnicalInfo());
@@ -351,6 +352,7 @@ void InterfaceSettings::save()
     Settings::self()->saveForceSingleClick(forceSingleClick->isChecked());
     Settings::self()->saveInfoTooltips(infoTooltips->isChecked());
     Settings::self()->saveShowStopButton(showStopButton->isChecked());
+    Settings::self()->saveShowVolumeSlider(showVolumeSlider->isChecked());
     Settings::self()->saveShowCoverWidget(showCoverWidget->isChecked());
     Settings::self()->saveShowRatingWidget(showRatingWidget->isChecked());
     Settings::self()->saveShowTechnicalInfo(showTechnicalInfo->isChecked());

--- a/gui/interfacesettings.ui
+++ b/gui/interfacesettings.ui
@@ -408,6 +408,13 @@
          </property>
         </widget>
        </item>
+       <item row="4" column="0" colspan="2">
+	<widget class="QCheckBox" name="showVolumeSlider">
+         <property name="text">
+	  <string>Show volume slider</string>
+	 </property>
+        </widget>
+       </item>
       </layout>
      </widget>
      <widget class="QWidget" name="tab_7">

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -1637,6 +1637,7 @@ void MainWindow::readSettings()
     tabWidget->setProperty(constUserSetting2Prop, Settings::self()->sidebar());
     coverWidget->setProperty(constUserSettingProp, Settings::self()->showCoverWidget());
     stopTrackButton->setProperty(constUserSettingProp, Settings::self()->showStopButton());
+    volumeSlider->setProperty(constUserSettingProp, Settings::self()->showVolumeSlider());
     responsiveSidebar=Settings::self()->responsiveSidebar();
     controlView(true);
     #if defined Q_OS_WIN
@@ -2839,6 +2840,7 @@ void MainWindow::controlView(bool forceUpdate)
 
     if (forceUpdate || -1==lastWidth || qAbs(lastWidth-width())>20) {
         bool stopEnabled = stopTrackButton->property(constUserSettingProp).toBool();
+	bool volumeEnabled = volumeSlider->property(constUserSettingProp).toBool();
         bool coverWidgetEnabled = coverWidget->property(constUserSettingProp).toBool();
         int tabWidgetStyle = tabWidget->property(constUserSetting2Prop).toInt();
         QStringList tabWidgetPages = tabWidget->property(constUserSettingProp).toStringList();
@@ -2858,6 +2860,14 @@ void MainWindow::controlView(bool forceUpdate)
             coverWidget->setEnabled(coverWidgetEnabled);
             stopTrackButton->setVisible(stopEnabled);
         }
+
+	if (!volumeEnabled) {
+		volumeSlider->setVisible(false);
+		volumeSliderSpacer->changeSize(-1,-1);
+	} else {
+		volumeSlider->setVisible(true);
+		volumeSliderSpacer->changeSize(4,4);
+	}
 
         if (expandInterfaceAction->isChecked() && (responsiveSidebar || forceUpdate)) {
             if (!responsiveSidebar || width()>Utils::scaleForDpi(450)) {

--- a/gui/settings.cpp
+++ b/gui/settings.cpp
@@ -661,6 +661,11 @@ bool Settings::showStopButton()
     return cfg.get("showStopButton", false);
 }
 
+bool Settings::showVolumeSlider()
+{
+	return cfg.get("showVolumeSlider", true);
+}
+
 bool Settings::showRatingWidget()
 {
     return cfg.get("showRatingWidget", false);
@@ -1154,6 +1159,11 @@ void Settings::saveShowCoverWidget(bool v)
 void Settings::saveShowStopButton(bool v)
 {
     cfg.set("showStopButton", v);
+}
+
+void Settings::saveShowVolumeSlider(bool v)
+{
+	cfg.set("showVolumeSlider", v);
 }
 
 void Settings::saveShowRatingWidget(bool v)

--- a/gui/settings.h
+++ b/gui/settings.h
@@ -138,6 +138,7 @@ public:
     QString lang();
     bool showCoverWidget();
     bool showStopButton();
+    bool showVolumeSlider();
     bool showRatingWidget();
     bool showTechnicalInfo();
     bool infoTooltips();
@@ -244,6 +245,7 @@ public:
     void saveLang(const QString &v);
     void saveShowCoverWidget(bool v);
     void saveShowStopButton(bool v);
+    void saveShowVolumeSlider(bool v);
     void saveShowRatingWidget(bool v);
     void saveShowTechnicalInfo(bool v);
     void saveInfoTooltips(bool v);


### PR DESCRIPTION
Added a configuration option to disable/enable the volume control slider on the main window.  I use the system volume control on my computer so the control in the UI was just taking up space for me.