### PR TITLE
Fix missing references to getuid when building on MacOS

### DIFF
--- a/3rdparty/qtsingleapplication/qtlocalpeer.cpp
+++ b/3rdparty/qtsingleapplication/qtlocalpeer.cpp
@@ -59,6 +59,7 @@ static PProcessIdToSessionId pProcessIdToSessionId = 0;
 #endif
 #if defined(Q_OS_UNIX)
 #include <time.h>
+#include <unistd.h>
 #endif
 
 const char* QtLocalPeer::ack = "ack";


### PR DESCRIPTION
Fixes build failures on MacOS.

On an M1 Macbook Air running Big Sur (11.6), builds against master are erroring with:

```
[  3%] Building CXX object 3rdparty/qtsingleapplication/CMakeFiles/qtsingleapplication.dir/qtlocalpeer.cpp.o
/Users/kevin/src/cantata/3rdparty/qtsingleapplication/qtlocalpeer.cpp:96:56: error: no member named 'getuid' in the global namespace
    socketName += QLatin1Char('-') + QString::number(::getuid(), 16);
```

The issue appears to have been introduced in https://github.com/CDrummond/cantata/commit/c8aa02230e37a63fccb88b62f05f4c7d62b4e9a5, I'm guessing due to some nested `#include <unistd.h>` that happens on Linux but not MacOS.