### PR TITLE
Fix total time after reordering play queue

### DIFF
--- a/models/playqueuemodel.cpp
+++ b/models/playqueuemodel.cpp
@@ -1162,6 +1162,7 @@ void PlayQueueModel::update(const QList<Song> &songList, bool isComplete)
                     Song old=songs.takeAt(existingPos);
 //                     old.pos=s.pos;
                     s.rating=old.rating;
+                    s.time=old.time;
                     songs.insert(i, isEmpty ? old : s);
                     endMoveRows();
                 }


### PR DESCRIPTION
Reordering the play queue by dragging and dropping often results in the total time at the bottom becoming incorrect (too short) due to moved songs having a `time` of 0.

Not sure if I'm missing something or this is specific to something about my setup, because I would have expected this to be noticed before. For me, it's consistently reproducible with at least Cantata 2.4.2 and master and the last few versions of MPD (currently on 0.23.2). Simplest reproduction: Add two songs to an an empty queue, drag the first one after the second one (or the second before the first) and watch the total time at the bottom change to reflect only the (now) second song in the list.

This change would be problematic if the song in the new list (which matches the id of an existing song) has the `time` field populated and it's different from the old one. I don't think that can happen, but I'm not familiar with this codebase. If that can happen, though, there's still a bug that would have to be addressed some other way because `s.time` is not being populated in all cases.