### PR TITLE
Remove superfluous line break from cover tooltip

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -35,6 +35,7 @@
 25. When searching for lyrics, if fail and artist starts with "The " then try
     again without "The "
 26. Add "Refresh" action to hover actions for podcasts.
+27. Remove superfluous blank space from the top of the cover tooltip.
 
 2.4.2
 -----

--- a/widgets/coverwidget.cpp
+++ b/widgets/coverwidget.cpp
@@ -79,11 +79,11 @@ void CoverLabel::updateToolTip(bool isEvent)
 
     QString toolTip;
     if (img.size().width()>Covers::constMaxSize.width() || img.size().height()>Covers::constMaxSize.height()) {
-        toolTip=QString("<br/>%1").arg(View::encode(img.scaled(Covers::constMaxSize, Qt::KeepAspectRatio, Qt::SmoothTransformation)));
+        toolTip=View::encode(img.scaled(Covers::constMaxSize, Qt::KeepAspectRatio, Qt::SmoothTransformation));
     } else if (CurrentCover::self()->fileName().isEmpty() || !QFile::exists(CurrentCover::self()->fileName())) {
-        toolTip=QString("<br/>%1").arg(View::encode(img));
+        toolTip=View::encode(img);
     } else {
-        toolTip=QString("<br/><img src=\"%1\"/>").arg(CurrentCover::self()->fileName());
+        toolTip=QString("<img src=\"%1\"/>").arg(CurrentCover::self()->fileName());
     }
     setToolTip(toolTip);
 


### PR DESCRIPTION
The line break appears to have originally separated textual information
in the tooltip from the cover image. All the textual information was
removed in 2d8566d74332491d79d6ecbc71a5c2d73fc914ba, so the image is now
the only thing in the tooltip and the line break was just creating an
empty space above it.