### PR TITLE
Make compatible with ffmpeg 5.0

### DIFF
--- a/replaygain/ffmpeginput.cpp
+++ b/replaygain/ffmpeginput.cpp
@@ -110,7 +110,7 @@ struct FfmpegInput::Handle {
     }
     AVFormatContext *formatContext;
     AVCodecContext *codecContext;
-    AVCodec *codec;
+    const AVCodec *codec;
     #if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(53, 35, 0)
     AVFrame *frame;
     int gotFrame;
@@ -211,7 +211,7 @@ FfmpegInput::FfmpegInput(const QString &fileName)
 
         if (ok) {
             QString floatCodec=QLatin1String(handle->codec->name)+QLatin1String("float");
-            AVCodec *possibleFloatCodec = avcodec_find_decoder_by_name(floatCodec.toLatin1().constData());
+            const AVCodec *possibleFloatCodec = avcodec_find_decoder_by_name(floatCodec.toLatin1().constData());
             if (possibleFloatCodec) {
                 handle->codec = possibleFloatCodec;
                 #if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(57, 89, 100) // Not 100% of version here!


### PR DESCRIPTION
ffmpeg 5.0 changes the API slightly that causes cantata to fail to build from source:

```
[ 96%] Building CXX object replaygain/CMakeFiles/cantata-replaygain.dir/ffmpeginput.cpp.o
.../replaygain/ffmpeginput.cpp: In constructor ‘FfmpegInput::FfmpegInput(const QString&)’:
.../replaygain/ffmpeginput.cpp:193:43: error: invalid conversion from ‘const AVCodec*’ to ‘AVCodec*’ [-fpermissive]
  193 |         handle->codec=avcodec_find_decoder(handle->formatContext->streams[handle->audioStream]->codecpar->codec_id);
      |                       ~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                           |
      |                                           const AVCodec*
.../replaygain/ffmpeginput.cpp:214:71: error: invalid conversion from ‘const AVCodec*’ to ‘AVCodec*’ [-fpermissive]
  214 |             AVCodec *possibleFloatCodec = avcodec_find_decoder_by_name(floatCodec.toLatin1().constData());
      |                                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                                                       |
      |                                                                       const AVCodec*
make[2]: *** [replaygain/CMakeFiles/cantata-replaygain.dir/build.make:90: replaygain/CMakeFiles/cantata-replaygain.dir/ffmpeginput.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:356: replaygain/CMakeFiles/cantata-replaygain.dir/all] Error 2
make: *** [Makefile:156: all] Error 2
```

Adding `const` to the relevant types (as done in this PR) appears to be enough to permit cantata to compile against both ffmpeg 4.4 and 5.0. 